### PR TITLE
feat: add schedule to autoscaling group

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
         terraform: [1.0.0, latest]
         example:
           [
-              "simple"
+              "simple", "full"
           ]
     defaults:
       run:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 
 .terraform.lock.hcl
+*.tfstate*

--- a/README.md
+++ b/README.md
@@ -1,16 +1,35 @@
 # terraform-aws-bastion-host-ssm
 This Terraform module installs a bastion host accessible via SSM only. The underlying EC2 instance
-has no ports opened.
+has no ports opened. All data is encrypted and a `resource_prefix` can be specified to integrate into
+your naming schema.
 
 The implemented connection method allows port forwarding for one port only. Multiple port forwardings
-can be realized by the user by creating multiple connections.
+can be realized by the user by creating multiple connections to the bastion host.
+
+Check the `examples` directory for the module usage.
 
 ## Features
 - use autoscaling groups to replace dead instances
-- (planned) have a schedule to shutdown the instance at night
+- have a schedule to shutdown the instance at night
 - (planned) use spot instances to save some money
 - (planned) provide IAM roles for easy access
 - (planned) provide a script to connect to the bastion from your local machine
+
+### Schedules
+Schedules allow to start and shutdown the instance at certain times. If your work hours are from 9 till 5 UTC, add
+
+```hcl
+module "bastion" {
+  ...
+  schedule {
+    start = "0 9 * * MON-FRI"
+    stop = "0 17 * * MON-FRI"
+  }
+}
+```
+
+The bastion host will automatically start at 9 UTC and shuts down at 17 UTC every day. Depending on the `instance_type` you will save
+more or less money.
 
 ## A Bastion Host
 - allows access to the infrastructure which is not exposed to the internet
@@ -46,6 +65,8 @@ can be realized by the user by creating multiple connections.
 |------|------|
 | [aws_ami_copy.latest_amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ami_copy) | resource |
 | [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_autoscaling_schedule.down](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_schedule) | resource |
+| [aws_autoscaling_schedule.up](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_schedule) | resource |
 | [aws_launch_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.egress_open_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -63,6 +84,7 @@ can be realized by the user by creating multiple connections.
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type of the bastion | `string` | `"t3.nano"` | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix used for all resources to make them unique. | `string` | `"bastion"` | no |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | Size of the root volume in GB | `number` | `8` | no |
+| <a name="input_schedule"></a> [schedule](#input\_schedule) | Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression. | <pre>object({<br>    start = string<br>    stop  = string<br>  })</pre> | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets to place the bastion in. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A list of tags to add to all resources. | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The bastion host resides in this VPC. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ module "bastion" {
   schedule {
     start = "0 9 * * MON-FRI"
     stop = "0 17 * * MON-FRI"
+
+    time_zone = "Europe/Berlin"
   }
 }
 ```
@@ -45,7 +47,7 @@ more or less money.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.53.0 |
 
 ## Providers
 
@@ -84,7 +86,7 @@ more or less money.
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type of the bastion | `string` | `"t3.nano"` | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix used for all resources to make them unique. | `string` | `"bastion"` | no |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | Size of the root volume in GB | `number` | `8` | no |
-| <a name="input_schedule"></a> [schedule](#input\_schedule) | Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression. | <pre>object({<br>    start = string<br>    stop  = string<br>  })</pre> | `null` | no |
+| <a name="input_schedule"></a> [schedule](#input\_schedule) | Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the `time_zone`. | <pre>object({<br>    start     = string<br>    stop      = string<br>    time_zone = string<br>  })</pre> | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets to place the bastion in. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A list of tags to add to all resources. | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The bastion host resides in this VPC. | `string` | n/a | yes |

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -1,0 +1,2 @@
+# Full Example
+Provides all values for the bastion module.

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -1,0 +1,40 @@
+module "bastion_host" {
+  source = "../../"
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  iam_role_path            = "/instances"
+  bastion_access_tag_value = "developers"
+
+  instance_type    = "t3.nano"
+  root_volume_size = 8
+
+  resource_prefix = "deve-bastion"
+
+  egress_open_tcp_ports = [3306, 5432]
+
+  schedule = {
+    start = "0 9 * * MON-FRI"
+    stop  = "0 17 * * MON-FRI"
+  }
+
+  tags = { "env" : "deve" }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.70"
+
+  name = "my-vpc"
+  cidr = "10.214.0.0/16"
+
+  azs             = data.aws_availability_zones.available.names
+  private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
+
+  map_public_ip_on_launch = false
+}

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -4,7 +4,7 @@ module "bastion_host" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  iam_role_path            = "/instances"
+  iam_role_path            = "/instances/"
   bastion_access_tag_value = "developers"
 
   instance_type    = "t3.nano"
@@ -17,6 +17,8 @@ module "bastion_host" {
   schedule = {
     start = "0 9 * * MON-FRI"
     stop  = "0 17 * * MON-FRI"
+
+    time_zone = "Europe/Berlin"
   }
 
   tags = { "env" : "deve" }

--- a/examples/full/provider.tf
+++ b/examples/full/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.53.0"
+      version = "3.53.0"
     }
   }
 }

--- a/examples/simple/provider.tf
+++ b/examples/simple/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.53.0"
+      version = "3.53.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -148,6 +148,7 @@ resource "aws_autoscaling_schedule" "up" {
 
   scheduled_action_name = "${var.resource_prefix}-start"
   recurrence            = var.schedule["start"]
+  time_zone             = var.schedule["time_zone"]
 
   min_size               = 1
   max_size               = 1
@@ -160,6 +161,7 @@ resource "aws_autoscaling_schedule" "down" {
 
   scheduled_action_name = "${var.resource_prefix}-stop"
   recurrence            = var.schedule["stop"]
+  time_zone             = var.schedule["time_zone"]
 
   min_size               = 0
   max_size               = 0

--- a/main.tf
+++ b/main.tf
@@ -142,3 +142,27 @@ resource "aws_autoscaling_group" "this" {
     create_before_destroy = true
   }
 }
+
+resource "aws_autoscaling_schedule" "up" {
+  count = var.schedule == null ? 0 : 1
+
+  scheduled_action_name = "${var.resource_prefix}-start"
+  recurrence            = var.schedule["start"]
+
+  min_size               = 1
+  max_size               = 1
+  desired_capacity       = 1
+  autoscaling_group_name = aws_autoscaling_group.this.name
+}
+
+resource "aws_autoscaling_schedule" "down" {
+  count = var.schedule == null ? 0 : 1
+
+  scheduled_action_name = "${var.resource_prefix}-stop"
+  recurrence            = var.schedule["stop"]
+
+  min_size               = 0
+  max_size               = 0
+  desired_capacity       = 0
+  autoscaling_group_name = aws_autoscaling_group.this.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,13 @@
+variable "schedule" {
+  type = object({
+    start = string
+    stop  = string
+  })
+  description = "Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression."
+
+  default = null
+}
+
 variable "iam_role_path" {
   type        = string
   description = "Role path for the created bastion instance profile."

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,10 @@
 variable "schedule" {
   type = object({
-    start = string
-    stop  = string
+    start     = string
+    stop      = string
+    time_zone = string
   })
-  description = "Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression."
+  description = "Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the `time_zone`."
 
   default = null
 }


### PR DESCRIPTION
## Description
This PR activates the schedule mechanism of the autoscaling group. The instance is started/stopped at the specified time. To activate scheduling add the `schedule` object to the module definition. As the instances are shut down for some hours, cost savings can be realized.

```hcl
module "bastion_host" {
  ...

  schedule = {
    start = "0 9 * * MON-FRI"
    stop  = "0 17 * * MON-FRI"
  }
}
```

## Migration
Due to the `time_zone` attribute the minimum version of the `aws` provider has been raised to `3.53.0`

## Verification
- [x] Deployed the `full` example and checked the connectivity

## Checklist
My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
