### PR TITLE
feat: make resource names configurable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,11 @@ repos:
       - id: mixed-line-ending
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.6.0
+    hooks:
+      - id: prettier
+        files: \.(json|yaml|yml)$ # do not process markdown. Conflicts with the terraform_docs hook
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.17
     hooks:
@@ -29,8 +34,3 @@ repos:
       - id: terraform_fmt
         args:
           - "--args=-recursive"
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.0
-    hooks:
-      - id: prettier
-        files: \.(json|md|yaml|yml)$

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ more or less money.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bastion_access_tag_value"></a> [bastion\_access\_tag\_value](#input\_bastion\_access\_tag\_value) | Value added as tag 'bastion-access' of the launched EC2 instance to be used to restrict access to the machine vie IAM. | `string` | `"developer"` | no |
 | <a name="input_egress_open_tcp_ports"></a> [egress\_open\_tcp\_ports](#input\_egress\_open\_tcp\_ports) | The list of TCP ports to open for outgoing traffic. | `list(number)` | n/a | yes |
-| <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Role path for the created bastion instance profile. | `string` | `"/"` | no |
+| <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Role path for the created bastion instance profile. Must end with '/' | `string` | `"/"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type of the bastion | `string` | `"t3.nano"` | no |
-| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix used for all resources to make them unique. Should usually end with a separator like '\_' or '-'. | `string` | `"bastion-"` | no |
+| <a name="input_resource_names"></a> [resource\_names](#input\_resource\_names) | Settings for generating resource names. Set the prefix and the separator according to your company style guide. | <pre>object({<br>    prefix    = string<br>    separator = string<br>  })</pre> | <pre>{<br>  "prefix": "bastion",<br>  "separator": "-"<br>}</pre> | no |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | Size of the root volume in GB | `number` | `8` | no |
-| <a name="input_schedule"></a> [schedule](#input\_schedule) | Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the `time_zone`. | <pre>object({<br>    start     = string<br>    stop      = string<br>    time_zone = string<br>  })</pre> | `null` | no |
+| <a name="input_schedule"></a> [schedule](#input\_schedule) | Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the 'time\_zone'. | <pre>object({<br>    start     = string<br>    stop      = string<br>    time_zone = string<br>  })</pre> | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets to place the bastion in. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A list of tags to add to all resources. | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The bastion host resides in this VPC. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # terraform-aws-bastion-host-ssm
+
 This Terraform module installs a bastion host accessible via SSM only. The underlying EC2 instance
 has no ports opened. All data is encrypted and a `resource_prefix` can be specified to integrate into
 your naming schema.
@@ -9,6 +10,7 @@ can be realized by the user by creating multiple connections to the bastion host
 Check the `examples` directory for the module usage.
 
 ## Features
+
 - use autoscaling groups to replace dead instances
 - have a schedule to shutdown the instance at night
 - (planned) use spot instances to save some money
@@ -16,6 +18,7 @@ Check the `examples` directory for the module usage.
 - (planned) provide a script to connect to the bastion from your local machine
 
 ### Schedules
+
 Schedules allow to start and shutdown the instance at certain times. If your work hours are from 9 till 5 UTC, add
 
 ```hcl
@@ -34,6 +37,7 @@ The bastion host will automatically start at 9 UTC and shuts down at 17 UTC ever
 more or less money.
 
 ## A Bastion Host
+
 - allows access to the infrastructure which is not exposed to the internet
 - designed to withstand attacks
 - also known as jump host
@@ -41,6 +45,7 @@ more or less money.
 [Wikipedia](https://en.wikipedia.org/wiki/Bastion_host)
 
 # Module Documentation
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -84,7 +89,7 @@ more or less money.
 | <a name="input_egress_open_tcp_ports"></a> [egress\_open\_tcp\_ports](#input\_egress\_open\_tcp\_ports) | The list of TCP ports to open for outgoing traffic. | `list(number)` | n/a | yes |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Role path for the created bastion instance profile. | `string` | `"/"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type of the bastion | `string` | `"t3.nano"` | no |
-| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix used for all resources to make them unique. | `string` | `"bastion"` | no |
+| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix used for all resources to make them unique. Should usually end with a separator like '\_' or '-'. | `string` | `"bastion-"` | no |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | Size of the root volume in GB | `number` | `8` | no |
 | <a name="input_schedule"></a> [schedule](#input\_schedule) | Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the `time_zone`. | <pre>object({<br>    start     = string<br>    stop      = string<br>    time_zone = string<br>  })</pre> | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets to place the bastion in. | `list(string)` | n/a | yes |

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -10,7 +10,10 @@ module "bastion_host" {
   instance_type    = "t3.nano"
   root_volume_size = 8
 
-  resource_prefix = "deve-bastion"
+  resource_names = {
+    prefix    = "bastion"
+    separator = "-"
+  }
 
   egress_open_tcp_ports = [3306, 5432]
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,11 +1,12 @@
 locals {
   # remove port 443. We add it by default as needed for SSM communication
-  clean_egress_open_tcp_ports = compact([for x in var.egress_open_tcp_ports : x == 443 ? "" : x])
+  clean_egress_open_tcp_ports    = compact([for x in var.egress_open_tcp_ports : x == 443 ? "" : x])
+  resource_prefix_with_separator = "${var.resource_names["prefix"]}${var.resource_names["separator"]}"
 
   asg_tags = merge(
     var.tags,
     {
-      "Name"           = var.resource_prefix
+      "Name"           = var.resource_names["prefix"]
       "bastion-access" = var.bastion_access_tag_value
   })
 }

--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "aws_autoscaling_group" "this" {
 resource "aws_autoscaling_schedule" "up" {
   count = var.schedule == null ? 0 : 1
 
-  scheduled_action_name = "${var.resource_prefix}-start"
+  scheduled_action_name = "${var.resource_prefix}start"
   recurrence            = var.schedule["start"]
   time_zone             = var.schedule["time_zone"]
 
@@ -159,7 +159,7 @@ resource "aws_autoscaling_schedule" "up" {
 resource "aws_autoscaling_schedule" "down" {
   count = var.schedule == null ? 0 : 1
 
-  scheduled_action_name = "${var.resource_prefix}-stop"
+  scheduled_action_name = "${var.resource_prefix}stop"
   recurrence            = var.schedule["stop"]
   time_zone             = var.schedule["time_zone"]
 

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ data "aws_ami" "latest_amazon_linux" {
 }
 
 resource "aws_ami_copy" "latest_amazon_linux" {
-  name        = var.resource_prefix
+  name        = var.resource_names["prefix"]
   description = "Copy of ${data.aws_ami.latest_amazon_linux.name}"
 
   source_ami_id     = data.aws_ami.latest_amazon_linux.id
@@ -26,7 +26,7 @@ resource "aws_ami_copy" "latest_amazon_linux" {
 }
 
 resource "aws_security_group" "this" {
-  name        = var.resource_prefix
+  name        = var.resource_names["prefix"]
   description = "Securing the bastion host"
   vpc_id      = var.vpc_id
 
@@ -65,7 +65,7 @@ module "instance_profile_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "4.14.0"
 
-  role_name        = var.resource_prefix
+  role_name        = var.resource_names["prefix"]
   role_description = "Instance profile for the bastion host to be able to connect to the machine"
   role_path        = var.iam_role_path
 
@@ -84,7 +84,7 @@ module "instance_profile_role" {
 }
 
 resource "aws_launch_configuration" "this" {
-  name_prefix = var.resource_prefix
+  name_prefix = var.resource_names["prefix"]
 
   image_id      = aws_ami_copy.latest_amazon_linux.id
   instance_type = var.instance_type
@@ -114,7 +114,7 @@ resource "aws_launch_configuration" "this" {
 }
 
 resource "aws_autoscaling_group" "this" {
-  name = var.resource_prefix
+  name = var.resource_names["prefix"]
 
   vpc_zone_identifier = var.subnet_ids
 
@@ -146,7 +146,7 @@ resource "aws_autoscaling_group" "this" {
 resource "aws_autoscaling_schedule" "up" {
   count = var.schedule == null ? 0 : 1
 
-  scheduled_action_name = "${var.resource_prefix}start"
+  scheduled_action_name = "${local.resource_prefix_with_separator}start"
   recurrence            = var.schedule["start"]
   time_zone             = var.schedule["time_zone"]
 
@@ -159,7 +159,7 @@ resource "aws_autoscaling_schedule" "up" {
 resource "aws_autoscaling_schedule" "down" {
   count = var.schedule == null ? 0 : 1
 
-  scheduled_action_name = "${var.resource_prefix}stop"
+  scheduled_action_name = "${local.resource_prefix_with_separator}stop"
   recurrence            = var.schedule["stop"]
   time_zone             = var.schedule["time_zone"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,14 +4,14 @@ variable "schedule" {
     stop      = string
     time_zone = string
   })
-  description = "Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the `time_zone`."
+  description = "Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the 'time_zone'."
 
   default = null
 }
 
 variable "iam_role_path" {
   type        = string
-  description = "Role path for the created bastion instance profile."
+  description = "Role path for the created bastion instance profile. Must end with '/'"
 
   default = "/"
 }
@@ -52,11 +52,17 @@ variable "subnet_ids" {
   description = "The subnets to place the bastion in."
 }
 
-variable "resource_prefix" {
-  type        = string
-  description = "The prefix used for all resources to make them unique. Should usually end with a separator like '_' or '-'."
+variable "resource_names" {
+  type = object({
+    prefix    = string
+    separator = string
+  })
+  description = "Settings for generating resource names. Set the prefix and the separator according to your company style guide."
 
-  default = "bastion-"
+  default = {
+    "prefix" : "bastion"
+    "separator" : "-"
+  }
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,9 +54,9 @@ variable "subnet_ids" {
 
 variable "resource_prefix" {
   type        = string
-  description = "The prefix used for all resources to make them unique."
+  description = "The prefix used for all resources to make them unique. Should usually end with a separator like '_' or '-'."
 
-  default = "bastion"
+  default = "bastion-"
 }
 
 variable "tags" {


### PR DESCRIPTION
# Description
Introduces settings for generating resource names within the module to better match several company guidelines. Use the new variable `resource_names` to set a common prefix and the separator character used that should be used within the resource names.

```hcl
module "bastion" {
  ...
  resource_names = {
    prefix = "deve-bastion"
    separator = "-"
  }
}
```

# Migrations required
The variable `resource_prefix` is gone. Move the value to the `resource_names` key `prefix` as shown above.

# Verification
Created a plan of the `full` example and checked the resource names.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
