### PR TITLE
chore: fix `commit-message` tag for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,29 +4,31 @@ updates:
     directory: "/examples/simple"
     schedule:
       interval: "daily"
-    commit_message:
+    commit-message:
       prefix: "weekly"
   - package-ecosystem: "terraform"
     directory: "/examples/full"
     schedule:
       interval: "weekly"
-    commit_message:
+    commit-message:
       prefix: "chore"
   - package-ecosystem: "terraform"
     directory: "/"
     schedule:
       interval: "daily"
-    commit_message:
+    commit-message:
       prefix: "chore"
 
   - package-ecosystem: "npm"
     directory: "/.release"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
       
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
-    commit_message:
+    commit-message:
       prefix: "chore"


### PR DESCRIPTION
# Description

Commit message for Dependabot can be specified with `commit-message`. Fixed that.

# Verification

None.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
