### PR TITLE
chore: do not update dependencies by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "chore"
+      prefix: "chore(deps)"
     ignore:
       - dependency-name: "hashicorp/aws"
 
@@ -14,11 +14,11 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore"
+      prefix: "ci"
       
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore"
+      prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: "terraform"
-    directory: "/examples/simple"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "weekly"
-  - package-ecosystem: "terraform"
-    directory: "/examples/full"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-  - package-ecosystem: "terraform"
     directory: "/"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "chore"
+    ignore:
+      - dependency-name: "hashicorp/aws"
 
   - package-ecosystem: "npm"
     directory: "/.release"


### PR DESCRIPTION
# Description

Dependabot should not update the examples or the providers of the main module. We specify the minimum version which can be used to apply the module. Thus we do not need to update anything.

The examples should always run with the minimum versions to make sure that the module is still deployable with them when the source was changed.

# Verification
None.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
