### PR TITLE
feat: add script to read AWS credentials from Keepass

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
 
 jobs:
+  shellcheck:
+    name: Check shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@1.1.0
+
   verify_format:
     name: Verify formatting
     strategy:
@@ -23,10 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         terraform: [1.0.0, latest]
-        example:
-          [
-              "simple", "full"
-          ]
+        example: ["simple", "full"]
     defaults:
       run:
         working-directory: examples/${{ matrix.example }}

--- a/README.md
+++ b/README.md
@@ -13,9 +13,18 @@ Check the `examples` directory for the module usage.
 
 - use autoscaling groups to replace dead instances
 - have a schedule to shutdown the instance at night
+- Keepass support for AWS credentials
 - (planned) use spot instances to save some money
 - (planned) provide IAM roles for easy access
 - (planned) provide a script to connect to the bastion from your local machine
+
+### Keepass Support For IAM User Credentials
+
+In case you are not using SSO or similar techniques you have to store the credentials for the user able to
+connect to the bastion host somewhere. We provide a little helper script to handle this scenario in a secure way.
+
+Create a [Keepass](https://keepass.info/download.html) database and add the [KPScript plugin](https://keepass.info/extensions/v2/kpscript/KPScript-2.50.zip).
+The `scripts/export_aws_credentials_from_keypass.sh` will read and export the credentials from the Keepass database.
 
 ### Schedules
 

--- a/scripts/export_aws_credentials_from_keypass.sh
+++ b/scripts/export_aws_credentials_from_keypass.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Reads the access key and secret access key for the Bastion user from Keepass.
+# The AWS credentials are exported and can be used by the AWS CLI.
+#
+# Variables:
+#   - KEEPASS_FILE: points to the Keepass database containing the AWS credentials
+#   - BASTION_USER_TITLE: the title of the entry in Keepass holding the AWS credentials
+#
+# Requirements:
+#   - Keepass installed (https://keepass.info/download.html)
+#   - KPScript plugin installed (https://keepass.info/extensions/v2/kpscript/KPScript-2.50.zip)
+#
+
+KEEPASS_FILE="/path/to/keepass/database.kdbx"
+BASTION_USER_TITLE="Bastion User"
+
+# get AWS credentials for user who is allowed to connect to the bastion
+read -sp 'Keepass Password: ' keepass_password
+
+access_key=`KPScript.exe -c:GetEntryString "${KEEPASS_FILE}" -Field:UserName -ref-Title:${BASTION_USER_TITLE} -FailIfNoEntry -pw:$keepass_password | head -n1`
+export AWS_ACCESS_KEY_ID=${access_key}
+
+secret_access_key=`KPScript.exe -c:GetEntryString "${KEEPASS_FILE}" -Field:Password -ref-Title:${BASTION_USER_TITLE} -FailIfNoEntry -pw:$keepass_password | head -n1`
+export AWS_SECRET_ACCESS_KEY=${secret_access_key}
+
+export AWS_SESSION_TOKEN=""

--- a/scripts/export_aws_credentials_from_keypass.sh
+++ b/scripts/export_aws_credentials_from_keypass.sh
@@ -11,6 +11,7 @@
 # Requirements:
 #   - Keepass installed (https://keepass.info/download.html)
 #   - KPScript plugin installed (https://keepass.info/extensions/v2/kpscript/KPScript-2.50.zip)
+#   - KPScript plugin must be available in the PATH
 #
 
 KEEPASS_FILE="/path/to/keepass/database.kdbx"

--- a/scripts/export_aws_credentials_from_keypass.sh
+++ b/scripts/export_aws_credentials_from_keypass.sh
@@ -17,12 +17,12 @@ KEEPASS_FILE="/path/to/keepass/database.kdbx"
 BASTION_USER_TITLE="Bastion User"
 
 # get AWS credentials for user who is allowed to connect to the bastion
-read -sp 'Keepass Password: ' keepass_password
+read -rsp 'Keepass Password: ' keepass_password
 
-access_key=`KPScript.exe -c:GetEntryString "${KEEPASS_FILE}" -Field:UserName -ref-Title:${BASTION_USER_TITLE} -FailIfNoEntry -pw:$keepass_password | head -n1`
+access_key=$(KPScript.exe -c:GetEntryString "${KEEPASS_FILE}" -Field:UserName -ref-Title:"${BASTION_USER_TITLE}" -FailIfNoEntry -pw:"${keepass_password}" | head -n1)
 export AWS_ACCESS_KEY_ID=${access_key}
 
-secret_access_key=`KPScript.exe -c:GetEntryString "${KEEPASS_FILE}" -Field:Password -ref-Title:${BASTION_USER_TITLE} -FailIfNoEntry -pw:$keepass_password | head -n1`
+secret_access_key=$(KPScript.exe -c:GetEntryString "${KEEPASS_FILE}" -Field:Password -ref-Title:"${BASTION_USER_TITLE}" -FailIfNoEntry -pw:"${keepass_password}" | head -n1)
 export AWS_SECRET_ACCESS_KEY=${secret_access_key}
 
 export AWS_SESSION_TOKEN=""


### PR DESCRIPTION
# Description

This PR adds a simple script to retrieve the AWS credentials for a user from Keepass.

# Verification
No verification done. Just a little helper script

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
