### PR TITLE
feat: add role and policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .terraform/
 .idea/
+.infracost/
 node_modules/
 
 .terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Check the `examples` directory for the module usage.
 - have a schedule to shutdown the instance at night
 - Keepass support for AWS credentials
 - (planned) use spot instances to save some money
-- (planned) provide IAM roles for easy access
+- provide IAM role for easy access
 - provide a script to connect to the bastion from your local machine
 
 ### Keepass Support For IAM User Credentials
@@ -43,7 +43,7 @@ The `scripts/export_aws_credentials_from_keypass.sh` will read and export the cr
 
 ### Schedules
 
-Schedules allow to start and shutdown the instance at certain times. If your work hours are from 9 till 5 UTC, add
+Schedules allow to start and shutdown the instance at certain times. If your work hours are from 9 till 5 in Berlin, add
 
 ```hcl
 module "bastion" {
@@ -57,8 +57,8 @@ module "bastion" {
 }
 ```
 
-The bastion host will automatically start at 9 UTC and shuts down at 17 UTC every day. Depending on the `instance_type` you will save
-more or less money.
+The bastion host will automatically start at 9 and shuts down at 17 every day (Berlin time). Depending on the `instance_type` you will save
+more or less money. Do not forget to adjust the timezone.
 
 ## Connect To The Bastion Host
 
@@ -116,7 +116,7 @@ way you can access the database, Redis cluster, ... directly from your localhost
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_instance_profile_role"></a> [instance\_profile\_role](#module\_instance\_profile\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.14.0 |
+| <a name="module_instance_profile_role"></a> [instance\_profile\_role](#module\_instance\_profile\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.15.1 |
 
 ## Resources
 
@@ -126,11 +126,15 @@ way you can access the database, Redis cluster, ... directly from your localhost
 | [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_autoscaling_schedule.down](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_schedule) | resource |
 | [aws_autoscaling_schedule.up](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_schedule) | resource |
+| [aws_iam_policy.access_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.access_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.access_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.egress_open_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.egress_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_ami.latest_amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_iam_policy_document.access_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -140,6 +144,7 @@ way you can access the database, Redis cluster, ... directly from your localhost
 | <a name="input_bastion_access_tag_value"></a> [bastion\_access\_tag\_value](#input\_bastion\_access\_tag\_value) | Value added as tag 'bastion-access' of the launched EC2 instance to be used to restrict access to the machine vie IAM. | `string` | `"developer"` | no |
 | <a name="input_egress_open_tcp_ports"></a> [egress\_open\_tcp\_ports](#input\_egress\_open\_tcp\_ports) | The list of TCP ports to open for outgoing traffic. | `list(number)` | n/a | yes |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Role path for the created bastion instance profile. Must end with '/' | `string` | `"/"` | no |
+| <a name="input_iam_user_arn"></a> [iam\_user\_arn](#input\_iam\_user\_arn) | ARN of the user who is allowed to assume the role giving access to the bastion host. | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type of the bastion | `string` | `"t3.nano"` | no |
 | <a name="input_resource_names"></a> [resource\_names](#input\_resource\_names) | Settings for generating resource names. Set the prefix and the separator according to your company style guide. | <pre>object({<br>    prefix    = string<br>    separator = string<br>  })</pre> | <pre>{<br>  "prefix": "bastion",<br>  "separator": "-"<br>}</pre> | no |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | Size of the root volume in GB | `number` | `8` | no |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ AWS-Gate is available at https://github.com/xen0l/aws-gate
 
 ### AWS CLI
 ```bash
+instance_id="my-bastion-instance-id"
+az="az-of-the-bastion"
+
+export AWS_ACCESS_KEY_ID="xxxxx"
+export AWS_SECRET_ACCESS_KEY="yyyyy"
+export AWS_SESSION_TOKEN=""
+
+aws sts assume-role --role-arn the-bastion-role-arn --role-session-profile bastion
+echo "export the credentials from above!"
+
 echo -e 'y\n' | ssh-keygen -t rsa -f bastion_key -N '' >/dev/null 2>&1
 ssh_public_key=$(cat bastion_key.pub)
 

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -4,7 +4,9 @@ module "bastion_host" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  iam_role_path            = "/instances/"
+  iam_role_path = "/instances/"
+  iam_user_arn  = module.bastion_user.iam_user_arn
+
   bastion_access_tag_value = "developers"
 
   instance_type    = "t3.nano"
@@ -42,4 +44,15 @@ module "vpc" {
   private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
 
   map_public_ip_on_launch = false
+}
+
+module "bastion_user" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
+  version = "4.15.1"
+
+  name = "bastion"
+
+  password_reset_required       = false
+  create_iam_user_login_profile = false
+  force_destroy                 = true
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -3,6 +3,8 @@ module "bastion_host" {
 
   egress_open_tcp_ports = [3306, 5432]
 
+  iam_user_arn = module.bastion_user.iam_user_arn
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 }
@@ -22,4 +24,15 @@ module "vpc" {
   private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
 
   map_public_ip_on_launch = false
+}
+
+module "bastion_user" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
+  version = "4.15.1"
+
+  name = "bastion"
+
+  password_reset_required       = false
+  create_iam_user_login_profile = false
+  force_destroy                 = true
 }

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ module "instance_profile_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "4.15.1"
 
-  role_name        = var.resource_names["prefix"]
+  role_name        = "${var.resource_names["prefix"]}${var.resource_names.separator}profile"
   role_description = "Instance profile for the bastion host to be able to connect to the machine"
   role_path        = var.iam_role_path
 

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,7 @@ resource "aws_security_group_rule" "egress_ssm" {
   from_port = 443
   to_port   = 443
   protocol  = "tcp"
+  # bastion host should be able to connect to all HTTPS sites
   # tfsec:ignore:aws-vpc-no-public-egress-sgr
   cidr_blocks = ["0.0.0.0/0"]
 }

--- a/role.tf
+++ b/role.tf
@@ -1,0 +1,111 @@
+resource "aws_iam_role" "access_bastion" {
+  name        = var.resource_names.prefix
+  description = "Role used to connect to the bastion instance."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Action    = "sts:AssumeRole",
+        Principal = { "AWS" : [var.iam_user_arn] }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "access_bastion" {
+  role       = aws_iam_role.access_bastion.name
+  policy_arn = aws_iam_policy.access_bastion.arn
+}
+
+resource "aws_iam_policy" "access_bastion" {
+  name        = var.resource_names.prefix
+  path        = var.iam_role_path
+  description = "Allows the access to the bastion host."
+
+  policy = data.aws_iam_policy_document.access_bastion.json
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "access_bastion" {
+  statement {
+    sid    = "Ec2FindBastion"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeInstances",
+    ]
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "ForAnyValue:StringEqualsIfExists"
+      values   = [var.bastion_access_tag_value]
+      variable = "aws:ResourceTag/Access"
+    }
+  }
+
+  statement {
+    sid    = "Ec2SendPublicSSHKey"
+    effect = "Allow"
+    actions = [
+      "ec2-instance-connect:SendSSHPublicKey"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ForAnyValue:StringEqualsIfExists"
+      values   = [var.bastion_access_tag_value]
+      variable = "aws:ResourceTag/Access"
+    }
+  }
+
+  statement {
+    sid    = "SsmStartSession"
+    effect = "Allow"
+    actions = [
+      "ssm:StartSession"
+    ]
+    resources = [
+      "arn:aws:ssm:${data.aws_region.this.name}::document/AWS-StartSSHSession"
+    ]
+  }
+
+  statement {
+    sid    = "SsmGetDocument"
+    effect = "Allow"
+    actions = [
+      "ssm:GetDocument",
+    ]
+    resources = [
+      "arn:aws:ssm:::document/SSM-SessionManagerRunShell"
+    ]
+  }
+
+  statement {
+    sid    = "SsmTerminateSession"
+    effect = "Allow"
+    actions = [
+      "ssm:TerminateSession",
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    sid    = "SsmDescribeSSMConnection"
+    effect = "Allow"
+    actions = [
+      "ssm:DescribeSessions",
+      "ssm:GetConnectionStatus",
+      "ssm:DescribeInstanceProperties",
+    ]
+    resources = [
+      "*"
+    ]
+  }
+}

--- a/role.tf
+++ b/role.tf
@@ -42,6 +42,8 @@ data "aws_iam_policy_document" "access_bastion" {
     ]
   }
 
+  # not critical as we use a condition and thus allowing a very limited number of resources only
+  # tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     sid    = "SSHBastion"
     effect = "Allow"
@@ -80,6 +82,8 @@ data "aws_iam_policy_document" "access_bastion" {
     ]
   }
 
+  # terminate session is not critical
+  # tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     sid    = "SsmTerminateSession"
     effect = "Allow"

--- a/role.tf
+++ b/role.tf
@@ -40,26 +40,21 @@ data "aws_iam_policy_document" "access_bastion" {
     resources = [
       "*"
     ]
-
-    condition {
-      test     = "ForAnyValue:StringEqualsIfExists"
-      values   = [var.bastion_access_tag_value]
-      variable = "aws:ResourceTag/Access"
-    }
   }
 
   statement {
-    sid    = "Ec2SendPublicSSHKey"
+    sid    = "SSHBastion"
     effect = "Allow"
     actions = [
-      "ec2-instance-connect:SendSSHPublicKey"
+      "ec2-instance-connect:SendSSHPublicKey",
+      "ssm:StartSession"
     ]
     resources = ["*"]
 
     condition {
       test     = "ForAnyValue:StringEqualsIfExists"
       values   = [var.bastion_access_tag_value]
-      variable = "aws:ResourceTag/Access"
+      variable = "aws:ResourceTag/bastion-access"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,25 @@
+variable "vpc_id" {
+  type        = string
+  description = "The bastion host resides in this VPC."
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "The subnets to place the bastion in."
+}
+
+variable "iam_role_path" {
+  type        = string
+  description = "Role path for the created bastion instance profile. Must end with '/'"
+
+  default = "/"
+}
+
+variable "iam_user_arn" {
+  type        = string
+  description = "ARN of the user who is allowed to assume the role giving access to the bastion host."
+}
+
 variable "schedule" {
   type = object({
     start     = string
@@ -7,13 +29,6 @@ variable "schedule" {
   description = "Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the 'time_zone'."
 
   default = null
-}
-
-variable "iam_role_path" {
-  type        = string
-  description = "Role path for the created bastion instance profile. Must end with '/'"
-
-  default = "/"
 }
 
 variable "bastion_access_tag_value" {
@@ -42,15 +57,6 @@ variable "egress_open_tcp_ports" {
   description = "The list of TCP ports to open for outgoing traffic."
 }
 
-variable "vpc_id" {
-  type        = string
-  description = "The bastion host resides in this VPC."
-}
-
-variable "subnet_ids" {
-  type        = list(string)
-  description = "The subnets to place the bastion in."
-}
 
 variable "resource_names" {
   type = object({


### PR DESCRIPTION
# Description

This PR adds the policies needed to connect to the Bastion. It also introduces a role which can be assumed by an IAM user.

Fill the `iam_user_arn` with the ARN of the user which should be allowed to connect to the Bastion host.

# Verification
Deployed the `full` example and connected to the Bastion host.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
