### PR TITLE
ci: skip TFSec for pushes on main branch

### DIFF
--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,12 +1,10 @@
 name: tfsec
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]  
   schedule:
-    - cron: '28 21 * * 0'
+    - cron: '15 3 * * 1'
 
 jobs:
   tfsec:


### PR DESCRIPTION
# Description

Skip the TFSec run on `main` branch. This is superfluous as every PR is based on the latest `main` branch and TFSec runs for the PR.

# Verification

None.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
