### PR TITLE
feat: add launch template for manual start

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,11 @@ module "bastion" {
 }
 ```
 
-The bastion host will automatically start at 9 and shuts down at 17 every day (Berlin time). Depending on the `instance_type` you will save
+The bastion host will automatically start at 9 and shuts down at 17 from monday to friday (Berlin time). Depending on the `instance_type` you will save
 more or less money. Do not forget to adjust the timezone.
+
+In case you have to start a bastin host outside the working hours use the launch template provided by the module and launch the
+new instance from the AWS CLI or Console. Don't forget to shut it down if you are done.
 
 ## Connect To The Bastion Host
 
@@ -140,6 +143,7 @@ way you can access the database, Redis cluster, ... directly from your localhost
 | [aws_iam_role.access_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.access_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) | resource |
+| [aws_launch_template.manual_start](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.egress_open_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.egress_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,35 @@ resource "aws_launch_configuration" "this" {
   }
 }
 
+resource "aws_launch_template" "manual_start" {
+  name        = var.resource_names.prefix
+  description = "Launches a bastion host"
+
+  image_id      = aws_ami_copy.latest_amazon_linux.id
+  instance_type = var.instance_type
+
+  vpc_security_group_ids = [aws_security_group.this.id]
+
+  update_default_version = true
+
+  iam_instance_profile {
+    name = module.instance_profile_role.iam_role_name
+  }
+
+  monitoring {
+    # no monitoring for manual instances
+    enabled = false
+  }
+
+  # use IMDSv2 to avoid warnings in Security Hub
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+    # if Docker container are used the hop limit should be at least 2
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_autoscaling_group" "this" {
   name = var.resource_names["prefix"]
 


### PR DESCRIPTION
# Description

If schedules are used the bastion is not running outside the business hours. This PR adds a launch template to have an easy way to start a bastion host from the AWS Console.

# Verification
No verification done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
