### PR TITLE
feat: make the EC2 monitoring configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,18 @@ can be realized by the user by creating multiple connections to the bastion host
 
 Check the `examples` directory for the module usage.
 
-## Cost Estimation (1.5.0)
+## Cost Estimation (1.7.0)
 
 ```
- Name                                                   Monthly Qty  Unit     Monthly Cost
+ Name                                                   Monthly Qty  Unit   Monthly Cost
 
  module.bastion_host.aws_autoscaling_group.this
  └─ module.bastion_host.aws_launch_configuration.this
-    ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)          730  hours           $4.38
-    ├─ EC2 detailed monitoring                                    7  metrics         $2.10
+    ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)          730  hours         $4.38
     └─ root_block_device
-       └─ Storage (general purpose SSD, gp3)                      8  GB              $0.76
+       └─ Storage (general purpose SSD, gp3)                      8  GB            $0.76
 
- OVERALL TOTAL                                                                       $7.24
+ OVERALL TOTAL                                                                     $5.14
 ```
 
 ## Features
@@ -159,9 +158,8 @@ way you can access the database, Redis cluster, ... directly from your localhost
 | <a name="input_egress_open_tcp_ports"></a> [egress\_open\_tcp\_ports](#input\_egress\_open\_tcp\_ports) | The list of TCP ports to open for outgoing traffic. | `list(number)` | n/a | yes |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Role path for the created bastion instance profile. Must end with '/' | `string` | `"/"` | no |
 | <a name="input_iam_user_arn"></a> [iam\_user\_arn](#input\_iam\_user\_arn) | ARN of the user who is allowed to assume the role giving access to the bastion host. | `string` | n/a | yes |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type of the bastion | `string` | `"t3.nano"` | no |
+| <a name="input_instance"></a> [instance](#input\_instance) | Defines the basic parameters for the EC2 instance used as Bastion host | <pre>object({<br>    type              = string # EC2 instance type<br>    root_volume_size  = number # in GB<br>    enable_monitoring = bool<br>  })</pre> | <pre>{<br>  "enable_monitoring": false,<br>  "root_volume_size": 8,<br>  "type": "t3.nano"<br>}</pre> | no |
 | <a name="input_resource_names"></a> [resource\_names](#input\_resource\_names) | Settings for generating resource names. Set the prefix and the separator according to your company style guide. | <pre>object({<br>    prefix    = string<br>    separator = string<br>  })</pre> | <pre>{<br>  "prefix": "bastion",<br>  "separator": "-"<br>}</pre> | no |
-| <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | Size of the root volume in GB | `number` | `8` | no |
 | <a name="input_schedule"></a> [schedule](#input\_schedule) | Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the 'time\_zone'. | <pre>object({<br>    start     = string<br>    stop      = string<br>    time_zone = string<br>  })</pre> | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets to place the bastion in. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A list of tags to add to all resources. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -57,8 +57,11 @@ module "bastion" {
 }
 ```
 
-The bastion host will automatically start at 9 and shuts down at 17 every day (Berlin time). Depending on the `instance_type` you will save
+The bastion host will automatically start at 9 and shuts down at 17 from monday to friday (Berlin time). Depending on the `instance_type` you will save
 more or less money. Do not forget to adjust the timezone.
+
+In case you have to start a bastin host outside the working hours use the launch template provided by the module and launch the
+new instance from the AWS CLI or Console. Don't forget to shut it down if you are done.
 
 ## Connect To The Bastion Host
 
@@ -140,6 +143,7 @@ way you can access the database, Redis cluster, ... directly from your localhost
 | [aws_iam_role.access_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.access_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) | resource |
+| [aws_launch_template.manual_start](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.egress_open_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.egress_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -9,8 +9,11 @@ module "bastion_host" {
 
   bastion_access_tag_value = "developers"
 
-  instance_type    = "t3.nano"
-  root_volume_size = 8
+  instance = {
+    type              = "t3.nano"
+    root_volume_size  = 8
+    enable_monitoring = false
+  }
 
   resource_names = {
     prefix    = "bastion"

--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,35 @@ resource "aws_launch_configuration" "this" {
   }
 }
 
+resource "aws_launch_template" "manual_start" {
+  name        = var.resource_names.prefix
+  description = "Launches a bastion host"
+
+  image_id      = aws_ami_copy.latest_amazon_linux.id
+  instance_type = var.instance_type
+
+  vpc_security_group_ids = [aws_security_group.this.id]
+
+  update_default_version = true
+
+  iam_instance_profile {
+    name = module.instance_profile_role.iam_role_name
+  }
+
+  monitoring {
+    # no monitoring for manual instances
+    enabled = false
+  }
+
+  # use IMDSv2 to avoid warnings in Security Hub
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+    # if Docker container are used the hop limit should be at least 2
+    http_put_response_hop_limit = 2
+  }
+}
+
 resource "aws_autoscaling_group" "this" {
   name = var.resource_names["prefix"]
 

--- a/main.tf
+++ b/main.tf
@@ -88,13 +88,13 @@ resource "aws_launch_configuration" "this" {
   name_prefix = var.resource_names["prefix"]
 
   image_id      = aws_ami_copy.latest_amazon_linux.id
-  instance_type = var.instance_type
+  instance_type = var.instance.type
 
   iam_instance_profile = module.instance_profile_role.iam_role_name
   security_groups      = [aws_security_group.this.id]
 
   root_block_device {
-    volume_size = var.root_volume_size
+    volume_size = var.instance.root_volume_size
     volume_type = "gp3"
 
     encrypted             = true
@@ -109,6 +109,8 @@ resource "aws_launch_configuration" "this" {
     http_put_response_hop_limit = 2
   }
 
+  enable_monitoring = var.instance.enable_monitoring
+
   lifecycle {
     create_before_destroy = true
   }
@@ -119,7 +121,7 @@ resource "aws_launch_template" "manual_start" {
   description = "Launches a bastion host"
 
   image_id      = aws_ami_copy.latest_amazon_linux.id
-  instance_type = var.instance_type
+  instance_type = var.instance.type
 
   vpc_security_group_ids = [aws_security_group.this.id]
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,20 +38,6 @@ variable "bastion_access_tag_value" {
   default = "developer"
 }
 
-variable "instance_type" {
-  type        = string
-  description = "EC2 instance type of the bastion"
-
-  default = "t3.nano"
-}
-
-variable "root_volume_size" {
-  type        = number
-  description = "Size of the root volume in GB"
-
-  default = 8
-}
-
 variable "egress_open_tcp_ports" {
   type        = list(number)
   description = "The list of TCP ports to open for outgoing traffic."
@@ -68,6 +54,21 @@ variable "resource_names" {
   default = {
     "prefix" : "bastion"
     "separator" : "-"
+  }
+}
+
+variable "instance" {
+  type = object({
+    type              = string # EC2 instance type
+    root_volume_size  = number # in GB
+    enable_monitoring = bool
+  })
+  description = "Defines the basic parameters for the EC2 instance used as Bastion host"
+
+  default = {
+    type              = "t3.nano"
+    root_volume_size  = 8
+    enable_monitoring = false
   }
 }
 


### PR DESCRIPTION
# Description

30% of the monthly costs were due to EC2 instance monitoring. This PR disables the monitoring by default. You can enable it by setting `instance.enable_monitoring` to `true`.

Variables have been restructured. See paragraph below.

# Migrations required

A new block `instance` has been introduced. Move the `instance_type` to `instance.type` and `root_volume_size` to `instance.root_volume_size`.

```hcl
module "bastion" {
  ...
  instance = {
    type              = "t3.nano"
    root_volume_size  = 8
  }
```
# Verification

No verification done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
