### PR TITLE
fix: add subnet id to manual launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,13 @@ resource "aws_launch_template" "manual_start" {
 
   update_default_version = true
 
+  network_interfaces {
+    associate_public_ip_address = false
+    security_groups             = [aws_security_group.this.id]
+    subnet_id                   = var.subnet_ids[0]
+    delete_on_termination       = true
+  }
+
   iam_instance_profile {
     name = module.instance_profile_role.iam_role_name
   }


### PR DESCRIPTION
# Description

Add the `subnet_id` to the launch template to make usage via AWS Console easier.

# Verification
No verification done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
