### PR TITLE
docs: fix doc as spot instances are implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check the `examples` directory for the module usage.
 - use autoscaling groups to replace dead instances
 - have a schedule to shutdown the instance at night
 - Keepass support for AWS credentials
-- (planned) use spot instances to save some money
+- use spot instances to save some money
 - provide IAM role for easy access
 - provide a script to connect to the bastion from your local machine
 


### PR DESCRIPTION
# Description

Fix the documentation as spot instances are no longer planned but implemented.

# Verification
None

# Checklist

- [ ] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
