### PR TITLE
fix: remove hard coded provider statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ way you can access the database, Redis cluster, ... directly from your localhost
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_instance_profile_role"></a> [instance\_profile\_role](#module\_instance\_profile\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.15.1 |
+| <a name="module_instance_profile_role"></a> [instance\_profile\_role](#module\_instance\_profile\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.17.0 |
 
 ## Resources
 

--- a/provider.tf
+++ b/provider.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = "eu-central-1"
-}


### PR DESCRIPTION
# Description

It's a module and we do not configure any providers here. Remove the provider settings from `provider.tf`.

# Verification
None

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
