### PR TITLE
fix: use name_prefix for autoscaling groups

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,7 +1,7 @@
 resource "aws_autoscaling_group" "on_demand" {
   count = var.instance.enable_spot ? 0 : 1
 
-  name = var.resource_names["prefix"]
+  name_prefix = "${var.resource_names["prefix"]}${var.resource_names["separator"]}"
 
   vpc_zone_identifier = var.subnet_ids
 


### PR DESCRIPTION
# Description

Use the `name_prefix` of the `aws_autoscaling_group` as the new resource is created before the old one is deleted. This results in a duplicate key error during apply if `name` is used.

# Verification
No verification done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
