### PR TITLE
fix: add tags to the manual launch template

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ way you can access the database, Redis cluster, ... directly from your localhost
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_instance_profile_role"></a> [instance\_profile\_role](#module\_instance\_profile\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.17.0 |
+| <a name="module_instance_profile_role"></a> [instance\_profile\_role](#module\_instance\_profile\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.17.1 |
 
 ## Resources
 

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -17,7 +17,7 @@ resource "aws_autoscaling_group" "on_demand" {
   launch_configuration = aws_launch_configuration.this.id
 
   dynamic "tag" {
-    for_each = local.asg_tags
+    for_each = local.bastion_runtime_tags
 
     content {
       key                 = tag.key
@@ -65,7 +65,7 @@ resource "aws_autoscaling_group" "on_spot" {
   }
 
   dynamic "tag" {
-    for_each = local.asg_tags
+    for_each = local.bastion_runtime_tags
 
     content {
       key                 = tag.key

--- a/locals.tf
+++ b/locals.tf
@@ -3,10 +3,13 @@ locals {
   clean_egress_open_tcp_ports    = compact([for x in var.egress_open_tcp_ports : x == 443 ? "" : x])
   resource_prefix_with_separator = "${var.resource_names["prefix"]}${var.resource_names["separator"]}"
 
-  asg_tags = merge(
+  bastion_runtime_tags = merge(
     var.tags,
     {
-      "Name"           = var.resource_names["prefix"]
-      "bastion-access" = var.bastion_access_tag_value
+      "Name"                             = local.bastion_host_name
+      "${local.bastion_access_tag_name}" = var.bastion_access_tag_value
   })
+
+  bastion_host_name       = var.resource_names["prefix"]
+  bastion_access_tag_name = "bastion-access"
 }

--- a/main.tf
+++ b/main.tf
@@ -144,4 +144,12 @@ resource "aws_launch_template" "manual_start" {
     # if Docker container are used the hop limit should be at least 2
     http_put_response_hop_limit = 2
   }
+
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = local.bastion_runtime_tags
+  }
+
+  tags = var.tags
 }


### PR DESCRIPTION
# Description

Adds `Name` and `bastion-access` tags to the launch template to enforce these tags at the started instance. Otherwise the script can't connect as it does not find any bastion host.

# Verification

The plan for the `spot` example looks good.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have used pre-commit hook to update the Terraform documentation
