### PR TITLE
fix!: replace KMS key id with key ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,19 +164,19 @@ way you can access the database, Redis cluster, ... directly from your localhost
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.53.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_instance_profile_role"></a> [instance\_profile\_role](#module\_instance\_profile\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.17.1 |
+| <a name="module_instance_profile_role"></a> [instance\_profile\_role](#module\_instance\_profile\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 5.2.0 |
 
 ## Resources
 
@@ -210,7 +210,7 @@ way you can access the database, Redis cluster, ... directly from your localhost
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Role path for the created bastion instance profile. Must end with '/' | `string` | `"/"` | no |
 | <a name="input_iam_user_arns"></a> [iam\_user\_arns](#input\_iam\_user\_arns) | ARNs of the user who are allowed to assume the role giving access to the bastion host. | `list(string)` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | Defines the basic parameters for the EC2 instance used as Bastion host | <pre>object({<br>    type              = string # EC2 instance type<br>    desired_capacity  = number # number of EC2 instances to run<br>    root_volume_size  = number # in GB<br>    enable_monitoring = bool<br><br>    enable_spot = bool<br>  })</pre> | <pre>{<br>  "desired_capacity": 1,<br>  "enable_monitoring": false,<br>  "enable_spot": false,<br>  "root_volume_size": 8,<br>  "type": "t3.nano"<br>}</pre> | no |
-| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ID of the KMS key used to encrypt the resources. | `string` | `null` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key used to encrypt the resources. | `string` | `null` | no |
 | <a name="input_resource_names"></a> [resource\_names](#input\_resource\_names) | Settings for generating resource names. Set the prefix and the separator according to your company style guide. | <pre>object({<br>    prefix    = string<br>    separator = string<br>  })</pre> | <pre>{<br>  "prefix": "bastion",<br>  "separator": "-"<br>}</pre> | no |
 | <a name="input_schedule"></a> [schedule](#input\_schedule) | Defines when to start and stop the instances. Use 'start' and 'stop' with a cron expression and add the 'time\_zone'. | <pre>object({<br>    start     = string<br>    stop      = string<br>    time_zone = string<br>  })</pre> | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets to place the bastion in. | `list(string)` | n/a | yes |

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -7,7 +7,7 @@ module "bastion_host" {
   iam_role_path = "/instances/"
   iam_user_arns = [module.bastion_user.iam_user_arn]
 
-  kms_key_id = module.kms_key.key_id
+  kms_key_arn = module.kms_key.key_arn
 
   bastion_access_tag_value = "developers"
 

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_ami_copy" "latest_amazon_linux" {
   source_ami_region = data.aws_region.this.name
 
   encrypted  = true
-  kms_key_id = var.kms_key_id
+  kms_key_id = var.kms_key_arn
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,9 +31,9 @@ variable "schedule" {
   default = null
 }
 
-variable "kms_key_id" {
+variable "kms_key_arn" {
   type        = string
-  description = "The ID of the KMS key used to encrypt the resources."
+  description = "The ARN of the KMS key used to encrypt the resources."
 
   default = null
 }


### PR DESCRIPTION
# Description

As described in #78, `aws_ami_copy` needs the ARN and not the ID of the KMS key. Quite confusing as the resource has a `key_id` attribute.

This PR replaces the module variable `kms_key_id` by `kms_key_arn`.

Closes #78

# Migrations required

`kms_key_id` has been replaced with `kms_key_arn`. The module needs the ARN of your KMS key and no longer the id.

# Verification

No verification done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
