### PR TITLE
chore: add issue templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Found a bug? Report it!
+title: ''
+labels: new, bug
+assignees: ''
+---
+
+<!-- Before submitting a bug, make sure that you meet the following requirements:
+  1. use the latest version of the module
+  2. read the documentation
+-->
+
+# Describe the bug
+
+A clear and concise description of what the bug is.
+
+# To Reproduce
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+# Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+# Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: Feature Request
+about: Propose a new feature
+title: ''
+labels: new, enhancement
+assignees: ''
+---
+
+# Describe the solution you'd like
+
+<!--
+  Provide a clear and concise description of what you want to happen. Add some sentences to describe the use case
+  to be solved by this feature.
+-->
+
+# Describe alternatives you've considered
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+# Suggest a solution
+
+<!--
+Things to include:
+
+- details of the technical implementation
+- tradeoffs made in design decisions
+ -caveats and considerations for the future
+
+If there are multiple solutions, please present each one separately. Save comparisons for the very end.
+-->
+
+# Additional context
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->


### PR DESCRIPTION
# Description

This PR adds templates for bug and feature issues to make sure that all relevant information is given when submitting the issue.

# Verification

Templates only. No verification needed.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
