### PR TITLE
chore: show project sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: [kayman-mk]
+custom: ['https://www.hapag-lloyd.com/']


### PR DESCRIPTION
# Description

Displays the current sponsors of the project on the GitHub project page.

# Verification

Not needed. No code change.

# Checklist

- [ ] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
