### PR TITLE
ci: update used Terraform modules with a `fix` PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
     ignore:
       - dependency-name: "hashicorp/aws"
 


### PR DESCRIPTION
# Description

Dependabot should update used Terraform modules with `fix(deps)` in the PR title as these changes are user relevant. Without a `fix` nothing is released.

# Verification

Not needed. No code change.

# Checklist

- [ ] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
