### PR TITLE
ci: do not validate single commit message

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -55,7 +55,7 @@ jobs:
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+          validateSingleCommit: false
           # Related to `validateSingleCommit` you can opt-in to validate that the PR
           # title matches a single commit to avoid confusion.
-          validateSingleCommitMatchesPrTitle: true
+          validateSingleCommitMatchesPrTitle: false


### PR DESCRIPTION
# Description

Disables the check to validate the commit message instead of the PR title. This repository uses the whole PR as commit message, so it makes no sense to validate the commit of the feature branch. This prevents the action from failing if there is one commit only.

# Verification

Not needed. CI change only.

# Checklist

- [ ] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
