### PR TITLE
ci: do not set the next release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,3 @@ jobs:
           include-v-in-tag: false
           signoff: "Matthias Kay <matthias.kay@hlag.com>"
           bootstrap-sha: "5213931527b84359dbfe1725e803af318082443f"
-          release-as: 2.0.17


### PR DESCRIPTION
# Description

Removes the superfluous setting for Release-Please which overrides the next version number of this module. Version numbers are detected automatically by the action.

# Verification

Not needed. CI change only.

# Checklist

- [ ] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have used pre-commit hook to update the Terraform documentation
