### PR TITLE
feat: add filter for AMI name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_region" "this" {
 }
 
-# find the latest Amazon Linux AMI and create a copy to be sure that is it present
+# find the latest Amazon Linux AMI and create a copy to be sure that it is present
 data "aws_ami" "latest_amazon_linux" {
   most_recent = true
 
@@ -9,7 +9,7 @@ data "aws_ami" "latest_amazon_linux" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+    values = [var.ami_name_filter]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -94,5 +94,5 @@ variable "tags" {
 
 variable "ami_name_filter" {
   description = "The search filter string for the bastion AMI."
-  default = "amzn2-ami-hvm-*-x86_64-ebs"
+  default     = "amzn2-ami-hvm-*-x86_64-ebs"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,8 @@ variable "tags" {
 
   default = {}
 }
+
+variable "ami_name_filter" {
+  description = "The search filter string for the bastion AMI."
+  default = "amzn2-ami-hvm-*-x86_64-ebs"
+}


### PR DESCRIPTION
# Description

Adds the new optional variable `ami_name__filter` which selects the AMI for the bastion host. Uses `amzn2-ami-hvm-*-x86_64-ebs` as default.

# Verification

Not done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have used pre-commit hook to update the Terraform documentation
