### PR TITLE
ci: do not run feature branch workflows in release branch

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -6,7 +6,8 @@ on:
       - opened
       - edited
       - synchronize
-
+    branches-ignore:
+      - 'release-please--branches--**
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,8 @@ name: CI Pull Request
 
 on:
   pull_request:
+    branches-ignore:
+      - 'release-please--branches--**'
 
 jobs:
   shellcheck:


### PR DESCRIPTION
# Description

This PR skips the workflows designated for feature branches in the release branch.

# Verification

Not needed. CI change only.

# Checklist

- [ ] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
