### PR TITLE
ci: fix `branches-ignore` rule for feature branch workflows

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -6,7 +6,8 @@ on:
       - opened
       - edited
       - synchronize
-
+    branches-ignore:
+      - 'release-please--branches--**
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -1,4 +1,4 @@
-name: "Lint PR"
+name: "Lint PR title"
 
 on:
   pull_request_target:
@@ -7,7 +7,8 @@ on:
       - edited
       - synchronize
     branches-ignore:
-      - 'release-please--branches--**
+      - 'release-please--branches--*'
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,7 @@ name: CI Pull Request
 on:
   pull_request:
     branches-ignore:
-      - 'release-please--branches--**'
+      - 'release-please--branches--*'
 
 jobs:
   shellcheck:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,8 @@ name: CI Pull Request
 
 on:
   pull_request:
+    branches-ignore:
+      - 'release-please--branches--**'
 
 jobs:
   shellcheck:


### PR DESCRIPTION
# Description

Fixes the branch ignore rule for workflows to exclude the release branches.

# Verification

Not needed. CI only.

# Checklist

- [ ] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
