### PR TITLE
feat: search for AMIs in current account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,14 @@
 data "aws_region" "this" {
 }
 
+data "aws_caller_identity" "this" {
+}
+
 # find the latest Amazon Linux AMI and create a copy to be sure that it is present
 data "aws_ami" "latest_amazon_linux" {
   most_recent = true
 
-  owners = ["amazon"]
+  owners = ["amazon", data.aws_caller_identity.this.id]
 
   filter {
     name   = "name"


### PR DESCRIPTION
# Description

Searches for the bastion AMI not only in the global Amazon account but also in the user's account. This allows to use a self-build custom AMI.

# Verification

No verification done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
