### PR TITLE
ci: allow semantic commit scope `main`

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -32,8 +32,11 @@ jobs:
             style
             test
           # Configure which scopes are allowed.
+          # deps - dependency updates
+          # main - for release-please (scope used for releases)
           scopes: |
             deps
+            main
           # Configure that a scope must always be provided.
           requireScope: false
           # Configure additional validation for the subject based on a regex.


### PR DESCRIPTION
# Description

The `main` scope is used by Release-Please for releases of the `main` branch. Thus this scope should be allowed.

# Verification

Not done as it is a CI change only.

# Checklist

- [ ] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
