### PR TITLE
feat: allow user defined instance profile

### DIFF
--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -18,6 +18,8 @@ module "bastion_host" {
     enable_monitoring = false
 
     enable_spot = false
+
+    profile_name = "AmazonSSMRoleForInstancesQuickSetup"
   }
 
   resource_names = {
@@ -33,6 +35,8 @@ module "bastion_host" {
 
     time_zone = "Europe/Berlin"
   }
+
+  ami_name_filter = "amzn2-ami-hvm-*-x86_64-ebs"
 
   tags = { "env" : "deve" }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -12,4 +12,6 @@ locals {
 
   bastion_host_name       = var.resource_names["prefix"]
   bastion_access_tag_name = "bastion-access"
+
+  bastion_instance_profile_name = var.instance["profile_name"] != "" ? var.instance["profile_name"] : module.instance_profile_role[0].iam_role_name
 }

--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ resource "aws_launch_configuration" "this" {
   image_id      = aws_ami_copy.latest_amazon_linux.id
   instance_type = var.instance.type
 
-  iam_instance_profile = module.instance_profile_role.iam_role_name
+  iam_instance_profile = local.bastion_instance_profile_name
   security_groups      = [aws_security_group.this.id]
 
   root_block_device {
@@ -134,7 +134,7 @@ resource "aws_launch_template" "manual_start" {
   update_default_version = true
 
   iam_instance_profile {
-    name = var.instance["profile_name"] != "" ? var.instance["profile_name"] : module.instance_profile_role[0].iam_role_name
+    name = local.bastion_instance_profile_name
   }
 
   monitoring {

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ module "instance_profile_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "5.9.2"
 
-  count = var.instance["profile_name"] > "" ? 1 : 0
+  count = var.instance["profile_name"] != "" ? 1 : 0
 
   role_name        = "${var.resource_names["prefix"]}${var.resource_names.separator}profile"
   role_description = "Instance profile for the bastion host to be able to connect to the machine"
@@ -134,7 +134,7 @@ resource "aws_launch_template" "manual_start" {
   update_default_version = true
 
   iam_instance_profile {
-    name = var.instance["profile_name"] > "" ? var.instance["profile_name"] : module.instance_profile_role[0].iam_role_name
+    name = var.instance["profile_name"] != "" ? var.instance["profile_name"] : module.instance_profile_role[0].iam_role_name
   }
 
   monitoring {

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,8 @@ module "instance_profile_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "5.9.2"
 
+  count = var.instance["profile_name"] > "" ? 1 : 0
+
   role_name        = "${var.resource_names["prefix"]}${var.resource_names.separator}profile"
   role_description = "Instance profile for the bastion host to be able to connect to the machine"
   role_path        = var.iam_role_path
@@ -132,7 +134,7 @@ resource "aws_launch_template" "manual_start" {
   update_default_version = true
 
   iam_instance_profile {
-    name = module.instance_profile_role.iam_role_name
+    name = var.instance["profile_name"] > "" ? var.instance["profile_name"] : module.instance_profile_role[0].iam_role_name
   }
 
   monitoring {

--- a/variables.tf
+++ b/variables.tf
@@ -10,14 +10,14 @@ variable "subnet_ids" {
 
 variable "iam_role_path" {
   type        = string
-  description = "Role path for the created bastion instance profile. Must end with '/'"
+  description = "Role path for the created bastion instance profile. Must end with '/'. Not used if instance[\"profile_name\"] is set."
 
   default = "/"
 }
 
 variable "iam_user_arns" {
   type        = list(string)
-  description = "ARNs of the user who are allowed to assume the role giving access to the bastion host."
+  description = "ARNs of the user who are allowed to assume the role giving access to the bastion host. Not used if instance[\"profile_name\"] is set.""
 }
 
 variable "schedule" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,10 @@ variable "instance" {
     enable_monitoring = bool
 
     enable_spot = bool
+
+    profile_name = string
   })
+
   description = "Defines the basic parameters for the EC2 instance used as Bastion host"
 
   default = {
@@ -82,6 +85,8 @@ variable "instance" {
     enable_monitoring = false
 
     enable_spot = false
+
+    profile_name = ""
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "iam_role_path" {
 
 variable "iam_user_arns" {
   type        = list(string)
-  description = "ARNs of the user who are allowed to assume the role giving access to the bastion host. Not used if instance[\"profile_name\"] is set.""
+  description = "ARNs of the user who are allowed to assume the role giving access to the bastion host. Not used if instance[\"profile_name\"] is set."
 }
 
 variable "schedule" {


### PR DESCRIPTION
# Description

Sometimes the caller of the module has already an instance profile available or wants to use the default profile created by AWS (`AmazonSSMRoleForInstancesQuickSetup`). The name of the IAM role can be given to the module via `var.instance["profile_name"]`.

# Verification

Not done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
