### PR TITLE
fix: create instance profile if no profile specified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ module "instance_profile_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "5.10.0"
 
-  count = var.instance["profile_name"] != "" ? 1 : 0
+  count = var.instance["profile_name"] != "" ? 0 : 1
 
   role_name        = "${var.resource_names["prefix"]}${var.resource_names.separator}profile"
   role_description = "Instance profile for the bastion host to be able to connect to the machine"


### PR DESCRIPTION
# Description

The instance profile was created if a user defined profile was given. This has been inverted.

# Verification

Not done

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
