### PR TITLE
ci: suppress welcome message for Dependabot PRs

### DIFF
--- a/.github/workflows/new-pr-opened.yml
+++ b/.github/workflows/new-pr-opened.yml
@@ -3,6 +3,9 @@ name: PR opened
 
 on:
   pull_request_target:
+    # GITHUB_TOKEN is readonly and the action will fail for Dependabot
+    branches-ignore:
+      - 'dependabot/**'
     types:
       - opened
 


### PR DESCRIPTION
# Description

Removes the welcome message from Dependabot PRs. It never worked as the `GITHUB_TOKEN` is created with read-only permissions and the workflow fails.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
