### PR TITLE
ci: fix Javascript comment character

### DIFF
--- a/.github/workflows/new-pr-opened.yml
+++ b/.github/workflows/new-pr-opened.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            # adds a comment to the PR (there is the issue API only which works work PRs too)
+            // adds a comment to the PR (there is the issue API only which works work PRs too)
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
# Description

Javascript comments should start with `//`. `#` does not work and results in strange error messages from the action.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
