### PR TITLE
fix: set token hop_limit to 1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,8 +111,7 @@ resource "aws_launch_configuration" "this" {
   metadata_options {
     http_endpoint = "enabled"
     http_tokens   = "required"
-    # if Docker container are used the hop limit should be at least 2
-    http_put_response_hop_limit = 2
+    http_put_response_hop_limit = 1
   }
 
   enable_monitoring = var.instance.enable_monitoring
@@ -146,8 +145,7 @@ resource "aws_launch_template" "manual_start" {
   metadata_options {
     http_endpoint = "enabled"
     http_tokens   = "required"
-    # if Docker container are used the hop limit should be at least 2
-    http_put_response_hop_limit = 2
+    http_put_response_hop_limit = 1
   }
 
   tag_specifications {


### PR DESCRIPTION
# Description

This PR reduces the hop_limit of the IMDS token to 1. This is a bastion host used for port forwarding only. There shouldn't be any jobs running.

Reason: The token should not leave the machine and we do not use Docker here (needs a hop_limit of at least 2).

# Verification

No verification done.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
