### PR TITLE
ci: fix the issue number to add comment for `/help` command

### DIFF
--- a/.github/workflows/slash_ops_commands.yml
+++ b/.github/workflows/slash_ops_commands.yml
@@ -27,7 +27,7 @@ jobs:
           script: |
             // adds a comment to the PR (there is the issue API, which works work PRs too)
             github.rest.issues.createComment({
-              issue_number: context.issue.number,
+              issue_number: context.payload.client_payload.github.payload.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: 'Hey there @${{ steps.vars.outputs.maintainer }}, could you please help @${{ github.event.client_payload.github.payload.comment.user.login }} out?'


### PR DESCRIPTION
# Description

Fixes the processing of `/help` by adding the correct PR number to the action. This way the comment can be added and a maintainer informed.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
