### PR TITLE
docs: add VPC endpoints to examples

### DIFF
--- a/examples/full/locals.tf
+++ b/examples/full/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  resource_prefix = "oss-bastion-host"
+}

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -4,7 +4,7 @@ module "bastion_host" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  iam_role_path = "/instances/"
+  iam_role_path = "/${local.resource_prefix}/"
   iam_user_arns = [module.bastion_user.iam_user_arn]
 
   kms_key_arn = module.kms_key.key_arn
@@ -23,7 +23,7 @@ module "bastion_host" {
   }
 
   resource_names = {
-    prefix    = "bastion"
+    prefix    = local.resource_prefix
     separator = "-"
   }
 
@@ -38,11 +38,7 @@ module "bastion_host" {
 
   ami_name_filter = "amzn2-ami-hvm-*-x86_64-ebs"
 
-  tags = { "env" : "deve" }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
+  tags = { "env" : "oss" }
 }
 
 module "kms_key" {
@@ -51,31 +47,18 @@ module "kms_key" {
 
   namespace               = "eg"
   stage                   = "test"
-  name                    = "chamber"
-  description             = "KMS key for chamber"
+  name                    = "${local.resource_prefix}-chamber"
+  description             = "KMS key for bastion host"
   deletion_window_in_days = 10
   enable_key_rotation     = true
   alias                   = "alias/parameter_store_key"
-}
-
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "2.70"
-
-  name = "my-vpc"
-  cidr = "10.214.0.0/16"
-
-  azs             = data.aws_availability_zones.available.names
-  private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
-
-  map_public_ip_on_launch = false
 }
 
 module "bastion_user" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
   version = "4.15.1"
 
-  name = "bastion"
+  name = "${local.resource_prefix}-bastion"
 
   password_reset_required       = false
   create_iam_user_login_profile = false

--- a/examples/full/vpc.tf
+++ b/examples/full/vpc.tf
@@ -1,0 +1,59 @@
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.70"
+
+  name = "${local.resource_prefix}-my-vpc"
+  cidr = "10.214.0.0/16"
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  azs             = data.aws_availability_zones.available.names
+  private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
+
+  map_public_ip_on_launch = false
+}
+
+resource "aws_security_group" "endpoint" {
+  name        = "${local.resource_prefix}-ssm"
+  description = "VPC endpoints"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = {
+    Name = "ssm"
+  }
+}
+
+resource "aws_security_group_rule" "ingress_ssm" {
+  security_group_id = aws_security_group.endpoint.id
+
+  type        = "ingress"
+  description = "allow HTTPS traffic from AWS"
+
+  protocol    = "tcp"
+  cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  from_port   = 443
+  to_port     = 443
+}
+
+resource "aws_vpc_endpoint" "endpoints" {
+  for_each = toset(["ssm", "ssmmessages", "ec2messages"])
+
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnets
+  security_group_ids = [aws_security_group.endpoint.id]
+
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${local.resource_prefix}-${each.key}"
+  }
+}

--- a/examples/simple/locals.tf
+++ b/examples/simple/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  resource_prefix = "oss-bastion-host"
+}

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -9,22 +9,7 @@ module "bastion_host" {
   subnet_ids = module.vpc.private_subnets
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-}
 
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "2.70"
-
-  name = "my-vpc"
-  cidr = "10.214.0.0/16"
-
-  azs             = data.aws_availability_zones.available.names
-  private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
-
-  map_public_ip_on_launch = false
-}
 
 module "bastion_user" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
@@ -35,40 +20,4 @@ module "bastion_user" {
   password_reset_required       = false
   create_iam_user_login_profile = false
   force_destroy                 = true
-}
-
-data "aws_region" "current" {}
-
-resource "aws_security_group" "ssm" {
-  name        = "ssm"
-  description = "SSM SG"
-  vpc_id      = module.vpc.vpc_id
-
-  tags = {
-    Name = "ssm"
-  }
-}
-# need for incoming connection to SSM
-resource "aws_security_group_rule" "ingress_ssm" {
-  security_group_id = aws_security_group.ssm.id
-  type              = "ingress"
-  description       = "allow HTTPS traffic"
-
-  from_port   = 443
-  to_port        = 443
-  protocol      = "tcp"
-  cidr_blocks = module.vpc.private_subnets_cidr_blocks
-}
-
-resource "aws_vpc_endpoint" "bastion_host" {
-  for_each                   = toset(["ssm", "ssmmessages", "ec2messages"])
-  vpc_id                       = module.vpc.vpc_id
-  service_name          = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
-  subnet_ids               = module.vpc.private_subnets
-  vpc_endpoint_type = "Interface"
-
-  security_group_ids  = [aws_security_group.ssm.id]
-  tags = {
-    Name = "bastion-host-${each.key}"
-  }
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -7,6 +7,11 @@ module "bastion_host" {
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
+
+  resource_names = {
+    prefix    = local.resource_prefix
+    separator = "-"
+  }
 }
 
 

--- a/examples/simple/vpc.tf
+++ b/examples/simple/vpc.tf
@@ -1,0 +1,59 @@
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.70"
+
+  name = "${local.resource_prefix}-my-vpc"
+  cidr = "10.214.0.0/16"
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  azs             = data.aws_availability_zones.available.names
+  private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
+
+  map_public_ip_on_launch = false
+}
+
+resource "aws_security_group" "endpoint" {
+  name        = "${local.resource_prefix}-ssm"
+  description = "VPC endpoints"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = {
+    Name = "ssm"
+  }
+}
+
+resource "aws_security_group_rule" "ingress_ssm" {
+  security_group_id = aws_security_group.endpoint.id
+
+  type        = "ingress"
+  description = "allow HTTPS traffic from AWS"
+
+  protocol    = "tcp"
+  cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  from_port   = 443
+  to_port     = 443
+}
+
+resource "aws_vpc_endpoint" "endpoints" {
+  for_each = toset(["ssm", "ssmmessages", "ec2messages"])
+
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnets
+  security_group_ids = [aws_security_group.endpoint.id]
+
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${local.resource_prefix}-${each.key}"
+  }
+}

--- a/examples/spot/locals.tf
+++ b/examples/spot/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  resource_prefix = "oss-bastion-host"
+}

--- a/examples/spot/main.tf
+++ b/examples/spot/main.tf
@@ -16,30 +16,18 @@ module "bastion_host" {
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
-}
 
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "2.70"
-
-  name = "my-vpc"
-  cidr = "10.214.0.0/16"
-
-  azs             = data.aws_availability_zones.available.names
-  private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
-
-  map_public_ip_on_launch = false
+  resource_names = {
+    prefix    = local.resource_prefix
+    separator = "-"
+  }
 }
 
 module "bastion_user" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
   version = "4.15.1"
 
-  name = "bastion"
+  name = "${local.resource_prefix}-bastion"
 
   password_reset_required       = false
   create_iam_user_login_profile = false

--- a/examples/spot/vpc.tf
+++ b/examples/spot/vpc.tf
@@ -1,0 +1,59 @@
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.70"
+
+  name = "${local.resource_prefix}-my-vpc"
+  cidr = "10.214.0.0/16"
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  azs             = data.aws_availability_zones.available.names
+  private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
+
+  map_public_ip_on_launch = false
+}
+
+resource "aws_security_group" "endpoint" {
+  name        = "${local.resource_prefix}-ssm"
+  description = "VPC endpoints"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = {
+    Name = "ssm"
+  }
+}
+
+resource "aws_security_group_rule" "ingress_ssm" {
+  security_group_id = aws_security_group.endpoint.id
+
+  type        = "ingress"
+  description = "allow HTTPS traffic from AWS"
+
+  protocol    = "tcp"
+  cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  from_port   = 443
+  to_port     = 443
+}
+
+resource "aws_vpc_endpoint" "endpoints" {
+  for_each = toset(["ssm", "ssmmessages", "ec2messages"])
+
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnets
+  security_group_ids = [aws_security_group.endpoint.id]
+
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${local.resource_prefix}-${each.key}"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -109,8 +109,8 @@ resource "aws_launch_configuration" "this" {
 
   # use IMDSv2 to avoid warnings in Security Hub
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 1
   }
 
@@ -143,8 +143,8 @@ resource "aws_launch_template" "manual_start" {
 
   # use IMDSv2 to avoid warnings in Security Hub
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 1
   }
 


### PR DESCRIPTION
# Description

Adds the missing VPC endpoints in the examples. Applying the examples was working technically but they were useless as you were not able to establish a connection to the bastion host.

Fixes #141 

# Verification

All examples have been applied. Connection to the bastion host is possible.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
