### PR TITLE
chore: activate Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>Hapag-Lloyd/Renovate-Global-Configuration"]
+}


### PR DESCRIPTION
# Description

Activates Renovate by adding a `renovate.json` file. We rely on the default Hapag-Lloyd settings. The Renovate job is started somewhere else.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
