### PR TITLE
ci: use standard workflow for Terraform

### DIFF
--- a/.config/tflint.hcl
+++ b/.config/tflint.hcl
@@ -1,0 +1,19 @@
+config {
+  force               = false
+  disabled_by_default = false
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "all"
+}
+
+plugin "aws" {
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+  # renovate: datasource=github-tags depName=terraform-linters/tflint-ruleset-aws
+  version = "0.21.2"
+
+  enabled    = true
+  deep_check = true
+  region     = "eu-central-1"
+}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
   lint-workflow:
     runs-on: ubuntu-latest
     container:
-      image: rhysd/actionlint:1.6.22
+      image: rhysd/actionlint:1.6.23
       options: --cpus 1 --user root
     steps:
       - uses: actions/checkout@v3
@@ -40,21 +40,4 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - run: bash <(curl -s https://raw.githubusercontent.com/CICDToolbox/json-lint/master/pipeline.sh)
-          
-  verify_examples:
-    name: Verify examples
-    strategy:
-      fail-fast: false
-      matrix:
-        terraform: [1.0.0, latest]
-        example: ["simple", "full"]
-    defaults:
-      run:
-        working-directory: examples/${{ matrix.example }}
-    runs-on: ubuntu-latest
-    container:
-      image: hashicorp/terraform:${{ matrix.terraform }}
-    steps:
-      - uses: actions/checkout@v3
-      - run: terraform init -get -backend=false -input=false
-      - run: terraform validate
+

--- a/.github/workflows/terraform-tfsec.yml
+++ b/.github/workflows/terraform-tfsec.yml
@@ -26,7 +26,7 @@ jobs:
           sarif_file: tfsec.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2.12.2
+        uses: github/codeql-action/upload-sarif@v2.2.3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: tfsec.sarif

--- a/.github/workflows/terraform-tfsec.yml
+++ b/.github/workflows/terraform-tfsec.yml
@@ -1,10 +1,11 @@
-name: tfsec
+---
+name: TfSec
 
+# yamllint disable-line rule:truthy
 on:
   pull_request:
-    branches: [ main ]  
   schedule:
-    - cron: '15 3 * * 1'
+    - cron: "47 3 * * 1"
 
 jobs:
   tfsec:
@@ -17,15 +18,15 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Run tfsec
         uses: tfsec/tfsec-sarif-action@v0.1.4
         with:
-          sarif_file: tfsec.sarif         
+          sarif_file: tfsec.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v2.12.2
         with:
           # Path to SARIF file relative to the root of the repository
-          sarif_file: tfsec.sarif  
+          sarif_file: tfsec.sarif

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -35,8 +35,6 @@ jobs:
 
   tflint:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/terraform-linters/tflint:v0.44.1@sha256:d7a49b9287c5d47566e664431ccfb2d7769bb8dc3bf544fa0145e6ba1479d153
     steps:
       - uses: actions/checkout@v3.3.0
 
@@ -53,11 +51,19 @@ jobs:
           role-session-name: tflint
           aws-region: ${{ vars.AWS_REGION }}
 
+      - name: install tflint
+        run: |
+          # renovate: datasource=github-tags depName=terraform-linters/tflint
+          tflint_version="0.44.1"
+          
+          curl -o tflint.zip -L https://github.com/terraform-linters/tflint/releases/download/v${tflint_version}/tflint_linux_amd64.zip
+          unzip tflint.zip
+
       - name: Show version
-        run: tflint --config=.config/tflint.hcl --version
+        run: ./tflint --config=.config/tflint.hcl --version
 
       - name: Init TFLint
-        run: tflint --config=.config/tflint.hcl --init
+        run: ./tflint --config=.config/tflint.hcl --init
 
       - name: Run TFLint
-        run: tflint --config=.config/tflint.hcl -f compact
+        run: ./tflint --config=.config/tflint.hcl -f compact

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,63 @@
+---
+name: Terraform
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform: [1.0.0, latest]
+        directories: [".", "examples/cost", "examples/simple", "examples/full"]
+    defaults:
+      run:
+        working-directory: ${{ matrix.directories }}
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+
+      - run: terraform -version
+
+      - run: terraform init -input=false -backend=false
+
+      - run: terraform validate
+
+  tflint:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/terraform-linters/tflint:v0.44.1@sha256:d7a49b9287c5d47566e664431ccfb2d7769bb8dc3bf544fa0145e6ba1479d153
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: actions/cache@v3.2.5
+        name: Cache plugin dir
+        with:
+          path: ~/.tflint.d/plugins
+          key: tflint-${{ hashFiles('.config/tflint.hcl') }}
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: ${{ secrets.AWS_TFLINT_ROLE_ARN }}
+          role-session-name: tflint
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Show version
+        run: tflint --config=.config/tflint.hcl --version
+
+      - name: Init TFLint
+        run: tflint --config=.config/tflint.hcl --init
+
+      - name: Run TFLint
+        run: tflint --config=.config/tflint.hcl -f compact

--- a/examples/cost/README.md
+++ b/examples/cost/README.md
@@ -1,0 +1,3 @@
+# Cost Example
+
+A typical setup. Used to calculate the monthly costs.

--- a/examples/cost/locals.tf
+++ b/examples/cost/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  resource_prefix = "oss-bastion-host"
+}

--- a/examples/cost/main.tf
+++ b/examples/cost/main.tf
@@ -12,6 +12,8 @@ module "bastion_host" {
     enable_monitoring = false
 
     enable_spot = true
+
+    profile_name = ""
   }
 
   instances_distribution = {

--- a/examples/cost/main.tf
+++ b/examples/cost/main.tf
@@ -1,0 +1,41 @@
+module "bastion_host" {
+  source = "../../"
+
+  egress_open_tcp_ports = [3306, 5432]
+
+  iam_user_arns = [module.bastion_user.iam_user_arn]
+
+  instance = {
+    type              = "t3.nano"
+    desired_capacity  = 2
+    root_volume_size  = 8
+    enable_monitoring = false
+
+    enable_spot = true
+  }
+
+  instances_distribution = {
+    on_demand_base_capacity                  = 1
+    on_demand_percentage_above_base_capacity = 0
+    spot_allocation_strategy                 = "lowest-price"
+  }
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  resource_names = {
+    prefix    = local.resource_prefix
+    separator = "-"
+  }
+}
+
+module "bastion_user" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
+  version = "4.15.1"
+
+  name = "${local.resource_prefix}-bastion"
+
+  password_reset_required       = false
+  create_iam_user_login_profile = false
+  force_destroy                 = true
+}

--- a/examples/cost/provider.tf
+++ b/examples/cost/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.15.1"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-central-1"
+}

--- a/examples/cost/vpc.tf
+++ b/examples/cost/vpc.tf
@@ -1,0 +1,59 @@
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.70"
+
+  name = "${local.resource_prefix}-my-vpc"
+  cidr = "10.214.0.0/16"
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  azs             = data.aws_availability_zones.available.names
+  private_subnets = ["10.214.1.0/24", "10.214.2.0/24", "10.214.3.0/24"]
+
+  map_public_ip_on_launch = false
+}
+
+resource "aws_security_group" "endpoint" {
+  name        = "${local.resource_prefix}-ssm"
+  description = "VPC endpoints"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = {
+    Name = "ssm"
+  }
+}
+
+resource "aws_security_group_rule" "ingress_ssm" {
+  security_group_id = aws_security_group.endpoint.id
+
+  type        = "ingress"
+  description = "allow HTTPS traffic from AWS"
+
+  protocol    = "tcp"
+  cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  from_port   = 443
+  to_port     = 443
+}
+
+resource "aws_vpc_endpoint" "endpoints" {
+  for_each = toset(["ssm", "ssmmessages", "ec2messages"])
+
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnets
+  security_group_ids = [aws_security_group.endpoint.id]
+
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${local.resource_prefix}-${each.key}"
+  }
+}

--- a/examples/spot/main.tf
+++ b/examples/spot/main.tf
@@ -12,6 +12,8 @@ module "bastion_host" {
     enable_monitoring = false
 
     enable_spot = true
+
+    profile_name = "AmazonSSMRoleForInstancesQuickSetup"
   }
 
   instances_distribution = {

--- a/locals.tf
+++ b/locals.tf
@@ -6,8 +6,8 @@ locals {
   bastion_runtime_tags = merge(
     var.tags,
     {
-      "Name"                             = local.bastion_host_name
-      "${local.bastion_access_tag_name}" = var.bastion_access_tag_value
+      "Name"                        = local.bastion_host_name
+      local.bastion_access_tag_name = var.bastion_access_tag_value
   })
 
   bastion_host_name       = var.resource_names["prefix"]

--- a/locals.tf
+++ b/locals.tf
@@ -6,8 +6,8 @@ locals {
   bastion_runtime_tags = merge(
     var.tags,
     {
-      "Name"                        = local.bastion_host_name
-      local.bastion_access_tag_name = var.bastion_access_tag_value
+      "Name"                          = local.bastion_host_name
+      (local.bastion_access_tag_name) = var.bastion_access_tag_value
   })
 
   bastion_host_name       = var.resource_names["prefix"]

--- a/variables.tf
+++ b/variables.tf
@@ -114,6 +114,7 @@ variable "tags" {
 }
 
 variable "ami_name_filter" {
+  type        =  string
   description = "The search filter string for the bastion AMI."
   default     = "amzn2-ami-hvm-*-x86_64-ebs"
 }


### PR DESCRIPTION
# Description

Adds the Hapag-Lloyd standard Terraform module workflow to the project. Currently supports TfSec, TfLint and a simple validate.

# Verification

Workflow ran in this project.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
