### PR TITLE
ci: allow TfLint cloud access via pre-deployed role

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -47,9 +47,9 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
-          role-to-assume: ${{ secrets.AWS_TFLINT_ROLE_ARN }}
+          role-to-assume: ${{ secrets.TFLINT_ROLE_ARN }}
           role-session-name: tflint
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.TFLINT_AWS_REGION }}
 
       - name: install tflint
         run: |


### PR DESCRIPTION
# Description

This PR uses the secrets provided by the GitHub organization to access a cloud account to be able to use TfLint. The hardcoded credentials weren't working any longer.

# Verification

The workflow ran on this PR. It failed before.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
