### PR TITLE
feat: add `var.ami_id` to fix the AMI used for the Bastion

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform: [1.3.0, latest]
+        terraform: [1.0.0, latest]
         directories: [".", "examples/cost", "examples/simple", "examples/full"]
     defaults:
       run:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform: [1.0.0, latest]
+        terraform: [1.3.0, latest]
         directories: [".", "examples/cost", "examples/simple", "examples/full"]
     defaults:
       run:

--- a/examples/cost/main.tf
+++ b/examples/cost/main.tf
@@ -26,8 +26,9 @@ module "bastion_host" {
     enable_monitoring = false
     enable_spot       = true
     profile_name      = ""
-    ami_id            = data.aws_ami.latest_amazon_linux.id
   }
+
+  ami_id            = data.aws_ami.latest_amazon_linux.id
 
   instances_distribution = {
     on_demand_base_capacity                  = 1

--- a/examples/cost/main.tf
+++ b/examples/cost/main.tf
@@ -1,3 +1,17 @@
+# don't do this in your module! Just to get an AMI id for the example. I don't want to update it every time.
+# use a hardcoded AMI id in your module, place it in `var.ami.id/region` and update it when you need to. This way you have an
+# immutable infrastructure and you can always roll back to the previous version of the AMI if something goes wrong.
+data "aws_ami" "latest_amazon_linux" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+  }
+}
+
 module "bastion_host" {
   source = "../../"
 
@@ -10,10 +24,9 @@ module "bastion_host" {
     desired_capacity  = 2
     root_volume_size  = 8
     enable_monitoring = false
-
-    enable_spot = true
-
-    profile_name = ""
+    enable_spot       = true
+    profile_name      = ""
+    ami_id            = data.aws_ami.latest_amazon_linux.id
   }
 
   instances_distribution = {

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -32,9 +32,9 @@ module "bastion_host" {
     enable_monitoring = false
     enable_spot       = false
     profile_name      = "AmazonSSMRoleForInstancesQuickSetup"
-
-    ami_id = data.aws_ami.latest_amazon_linux.id
   }
+
+  ami_id = data.aws_ami.latest_amazon_linux.id
 
   resource_names = {
     prefix    = local.resource_prefix

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -1,3 +1,17 @@
+# don't do this in your module! Just to get an AMI id for the example. I don't want to update it every time.
+# use a hardcoded AMI id in your module, place it in `var.ami.id/region` and update it when you need to. This way you have an
+# immutable infrastructure and you can always roll back to the previous version of the AMI if something goes wrong.
+data "aws_ami" "latest_amazon_linux" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+  }
+}
+
 module "bastion_host" {
   source = "../../"
 
@@ -16,10 +30,10 @@ module "bastion_host" {
     desired_capacity  = 2
     root_volume_size  = 8
     enable_monitoring = false
+    enable_spot       = false
+    profile_name      = "AmazonSSMRoleForInstancesQuickSetup"
 
-    enable_spot = false
-
-    profile_name = "AmazonSSMRoleForInstancesQuickSetup"
+    ami_id = data.aws_ami.latest_amazon_linux.id
   }
 
   resource_names = {
@@ -35,8 +49,6 @@ module "bastion_host" {
 
     time_zone = "Europe/Berlin"
   }
-
-  ami_name_filter = "amzn2-ami-hvm-*-x86_64-ebs"
 
   tags = { "env" : "oss" }
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,9 +1,27 @@
+# don't do this in your module! Just to get an AMI id for the example. I don't want to update it every time.
+# use a hardcoded AMI id in your module, place it in `var.ami.id/region` and update it when you need to. This way you have an
+# immutable infrastructure and you can always roll back to the previous version of the AMI if something goes wrong.
+data "aws_ami" "latest_amazon_linux" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+  }
+}
+
 module "bastion_host" {
   source = "../../"
 
   egress_open_tcp_ports = [3306, 5432]
 
   iam_user_arns = [module.bastion_user.iam_user_arn]
+
+  instance = {
+    ami_id = data.aws_ami.latest_amazon_linux.id
+  }
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -19,9 +19,7 @@ module "bastion_host" {
 
   iam_user_arns = [module.bastion_user.iam_user_arn]
 
-  instance = {
-    ami_id = data.aws_ami.latest_amazon_linux.id
-  }
+  ami_id = data.aws_ami.latest_amazon_linux.id
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets

--- a/examples/spot/main.tf
+++ b/examples/spot/main.tf
@@ -1,3 +1,17 @@
+# don't do this in your module! Just to get an AMI id for the example. I don't want to update it every time.
+# use a hardcoded AMI id in your module, place it in `var.ami.id/region` and update it when you need to. This way you have an
+# immutable infrastructure and you can always roll back to the previous version of the AMI if something goes wrong.
+data "aws_ami" "latest_amazon_linux" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+  }
+}
+
 module "bastion_host" {
   source = "../../"
 
@@ -10,10 +24,9 @@ module "bastion_host" {
     desired_capacity  = 2
     root_volume_size  = 8
     enable_monitoring = false
-
-    enable_spot = true
-
-    profile_name = "AmazonSSMRoleForInstancesQuickSetup"
+    enable_spot       = true
+    profile_name      = "AmazonSSMRoleForInstancesQuickSetup"
+    ami_id            = data.aws_ami.latest_amazon_linux.id
   }
 
   instances_distribution = {

--- a/examples/spot/main.tf
+++ b/examples/spot/main.tf
@@ -26,8 +26,9 @@ module "bastion_host" {
     enable_monitoring = false
     enable_spot       = true
     profile_name      = "AmazonSSMRoleForInstancesQuickSetup"
-    ami_id            = data.aws_ami.latest_amazon_linux.id
   }
+
+  ami_id            = data.aws_ami.latest_amazon_linux.id
 
   instances_distribution = {
     on_demand_base_capacity                  = 1

--- a/locals.tf
+++ b/locals.tf
@@ -17,11 +17,11 @@ locals {
 
   panic_button_switch_off_lambda_source_file_name = "panic_button_switch_off.py"
   panic_button_switch_off_lambda_source           = "${path.module}/lambda/${local.panic_button_switch_off_lambda_source_file_name}"
-  panic_button_switch_off_lambda_name = "${var.resource_names.prefix}${var.resource_names.separator}panic-button-off"
+  panic_button_switch_off_lambda_name             = "${var.resource_names.prefix}${var.resource_names.separator}panic-button-off"
 
   panic_button_switch_on_lambda_source_file_name = "panic_button_switch_on.py"
   panic_button_switch_on_lambda_source           = "${path.module}/lambda/${local.panic_button_switch_on_lambda_source_file_name}"
-  panic_button_switch_on_lambda_name = "${var.resource_names.prefix}${var.resource_names.separator}panic-button-on"
+  panic_button_switch_on_lambda_name             = "${var.resource_names.prefix}${var.resource_names.separator}panic-button-on"
 
   auto_scaling_group = var.instance.enable_spot ? aws_autoscaling_group.on_spot[0] : aws_autoscaling_group.on_demand[0]
 }

--- a/main.tf
+++ b/main.tf
@@ -21,8 +21,8 @@ resource "aws_ami_copy" "latest_amazon_linux" {
   name        = var.resource_names["prefix"]
   description = "Copy of ${data.aws_ami.deprecated_latest_amazon_linux.name}"
 
-  source_ami_id     = var.instance.ami_id != null ? var.instance.ami_id : data.aws_ami.deprecated_latest_amazon_linux.id
-  source_ami_region = var.instance.ami_id != null ? var.instance.ami_id : data.aws_region.this.name
+  source_ami_id     = var.ami_id != null ? var.ami_id : data.aws_ami.deprecated_latest_amazon_linux.id
+  source_ami_region = data.aws_region.this.name
 
   encrypted  = true
   kms_key_id = var.kms_key_arn

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,8 @@ data "aws_caller_identity" "this" {
 }
 
 # find the latest Amazon Linux AMI and create a copy to be sure that it is present
-data "aws_ami" "latest_amazon_linux" {
+# to be removed with the next major update (3.0.0)
+data "aws_ami" "deprecated_latest_amazon_linux" {
   most_recent = true
 
   owners = ["amazon", data.aws_caller_identity.this.id]
@@ -18,10 +19,10 @@ data "aws_ami" "latest_amazon_linux" {
 
 resource "aws_ami_copy" "latest_amazon_linux" {
   name        = var.resource_names["prefix"]
-  description = "Copy of ${data.aws_ami.latest_amazon_linux.name}"
+  description = "Copy of ${data.aws_ami.deprecated_latest_amazon_linux.name}"
 
-  source_ami_id     = data.aws_ami.latest_amazon_linux.id
-  source_ami_region = data.aws_region.this.name
+  source_ami_id     = var.instance.ami_id != null ? var.instance.ami_id : data.aws_ami.deprecated_latest_amazon_linux.id
+  source_ami_region = var.instance.ami_id != null ? var.instance.ami_id : data.aws_region.this.name
 
   encrypted  = true
   kms_key_id = var.kms_key_arn

--- a/panic-button-off.tf
+++ b/panic-button-off.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "panic_button_off" {
       "ec2:DescribeInstances"
     ]
     resources = ["*"]
-    effect = "Allow"
+    effect    = "Allow"
   }
 
   statement {
@@ -48,10 +48,10 @@ data "aws_iam_policy_document" "panic_button_off" {
   }
 
   statement {
-    sid="UpdateASG"
-    actions = ["autoscaling:UpdateAutoScalingGroup"]
+    sid       = "UpdateASG"
+    actions   = ["autoscaling:UpdateAutoScalingGroup"]
     resources = [local.auto_scaling_group.arn]
-    effect = "Allow"
+    effect    = "Allow"
   }
 }
 
@@ -93,14 +93,14 @@ resource "aws_lambda_function" "panic_button_off" {
   timeout          = 30
   memory_size      = 256
   #package_type     = "Zip"
-  publish          = true
-  role             = aws_iam_role.panic_button_off_execution.arn
-  runtime          = "python3.9"
+  publish = true
+  role    = aws_iam_role.panic_button_off_execution.arn
+  runtime = "python3.9"
 
   environment {
     variables = {
       AUTO_SCALING_GROUP_NAME = local.auto_scaling_group.name
-      BASTION_HOST_NAME = local.bastion_host_name
+      BASTION_HOST_NAME       = local.bastion_host_name
 
       LOG_LEVEL = "info"
     }

--- a/panic-button-on.tf
+++ b/panic-button-on.tf
@@ -23,17 +23,17 @@ data "aws_iam_policy_document" "panic_button_on_assume_role" {
 
 data "aws_iam_policy_document" "panic_button_on" {
   statement {
-    sid="UpdateASG"
-    actions = ["autoscaling:UpdateAutoScalingGroup", "autoscaling:DeleteScheduledAction"]
+    sid       = "UpdateASG"
+    actions   = ["autoscaling:UpdateAutoScalingGroup", "autoscaling:DeleteScheduledAction"]
     resources = [local.auto_scaling_group.arn]
-    effect = "Allow"
+    effect    = "Allow"
   }
 
   statement {
-    sid="DescribeASG"
-    actions = ["autoscaling:DescribeScheduledActions"]
+    sid       = "DescribeASG"
+    actions   = ["autoscaling:DescribeScheduledActions"]
     resources = ["*"]
-    effect = "Allow"
+    effect    = "Allow"
   }
 }
 
@@ -81,9 +81,9 @@ resource "aws_lambda_function" "panic_button_on" {
 
   environment {
     variables = {
-      AUTO_SCALING_GROUP_NAME = local.auto_scaling_group.name
-      AUTO_SCALING_GROUP_MIN_SIZE = local.auto_scaling_group.min_size
-      AUTO_SCALING_GROUP_MAX_SIZE = local.auto_scaling_group.max_size
+      AUTO_SCALING_GROUP_NAME             = local.auto_scaling_group.name
+      AUTO_SCALING_GROUP_MIN_SIZE         = local.auto_scaling_group.min_size
+      AUTO_SCALING_GROUP_MAX_SIZE         = local.auto_scaling_group.max_size
       AUTO_SCALING_GROUP_DESIRED_CAPACITY = local.auto_scaling_group.desired_capacity
 
       LOG_LEVEL = "info"

--- a/provider.tf
+++ b/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     archive = {
-      source = "hashicorp/archive"
+      source  = "hashicorp/archive"
       version = ">= 2.0.0"
     }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.0.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -70,10 +70,10 @@ variable "instance" {
     desired_capacity  = number # number of EC2 instances to run
     root_volume_size  = number # in GB
     enable_monitoring = bool
+    enable_spot       = bool
+    profile_name      = string
 
-    enable_spot = bool
-
-    profile_name = string
+    ami_id = optional(string) # AMI ID to use for the bastion host
   })
 
   description = "Defines the basic parameters for the EC2 instance used as Bastion host"
@@ -83,10 +83,8 @@ variable "instance" {
     desired_capacity  = 1
     root_volume_size  = 8
     enable_monitoring = false
-
-    enable_spot = false
-
-    profile_name = ""
+    enable_spot       = false
+    profile_name      = ""
   }
 }
 
@@ -114,7 +112,7 @@ variable "tags" {
 }
 
 variable "ami_name_filter" {
-  type        =  string
-  description = "The search filter string for the bastion AMI."
+  type        = string
+  description = "(Deprecated; set instance.ami_id instead; will be removed in v3.0.0) The search filter string for the bastion AMI."
   default     = "amzn2-ami-hvm-*-x86_64-ebs"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -72,8 +72,6 @@ variable "instance" {
     enable_monitoring = bool
     enable_spot       = bool
     profile_name      = string
-
-    ami_id = optional(string) # AMI ID to use for the bastion host
   })
 
   description = "Defines the basic parameters for the EC2 instance used as Bastion host"
@@ -113,6 +111,12 @@ variable "tags" {
 
 variable "ami_name_filter" {
   type        = string
-  description = "(Deprecated; set instance.ami_id instead; will be removed in v3.0.0) The search filter string for the bastion AMI."
+  description = "(Deprecated; set var.ami_id instead; will be removed in v3.0.0) The search filter string for the bastion AMI."
   default     = "amzn2-ami-hvm-*-x86_64-ebs"
+}
+
+variable "ami_id" {
+  type        = string
+  description = "The AMI ID to use for the bastion host. If not set, the latest AMI matching the ami_name_filter will be used."
+  default     = null
 }


### PR DESCRIPTION
# Description

The infrastructure should be immutable, i.e. applying the same infrastructure every week shouldn't change anything. At the moment the AMI id changes when a new AMI is published. This might introduce problems as the image is changed. It also increases the elapsed time of your workflows/pipelines by roughly 4 minutes.

This PR adds an optional `var.ami_id`. In case it is filled, this AMI is used for the Bastion EC2 instance. The `var.ami_name_filter` is now deprecated and will be removed with version 3.0.0 of the module.

I recommend using this new parameter. But make sure that you have an update procedure in place to update the AMI id regularly.

# Verification

Apply the `simple` example --> Bastion host is setup and boots

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
