### PR TITLE
chore: use PAT to auto-approve Renovate PRs

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,0 +1,17 @@
+---
+name: Approve all Renovate PRs automatically
+
+# yamllint disable-line rule:truthy
+on: pull_request_target
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.actor == 'renovate[bot]'
+    steps:
+      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4  # v3.2.1
+        with:
+          review-message: "Auto approved Renovate PR by organization"
+          github-token: ${{ secrets.PAT_FOR_PR_AUTO_APPROVAL }}


### PR DESCRIPTION
Uses the new PAT `secrets.PAT_FOR_PR_AUTO_APPROVAL` to approve Renovate PRs. Temporary created access tokens via GitHub App do not work here as the app is not a valid approver.

To use the auto-merge feature, make sure that the owner of the PAT is in the list of approvers.