### PR TITLE
fix: allow panic lambdas to modify autoscaling schedule

### DIFF
--- a/panic-button-on.tf
+++ b/panic-button-on.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "panic_button_on_assume_role" {
 data "aws_iam_policy_document" "panic_button_on" {
   statement {
     sid       = "UpdateASG"
-    actions   = ["autoscaling:UpdateAutoScalingGroup", "autoscaling:DeleteScheduledAction"]
+    actions   = ["autoscaling:UpdateAutoScalingGroup", "autoscaling:BatchDeleteScheduledAction"]
     resources = [local.auto_scaling_group.arn]
     effect    = "Allow"
   }

--- a/role.tf
+++ b/role.tf
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "access_bastion" {
       "autoscaling:BatchDeleteScheduledAction"
     ]
     resources = [
-      "*"
+      var.instance.enable_spot ? aws_autoscaling_group.on_spot.arn : aws_autoscaling_group.on_demand.arn
     ]
   }
 

--- a/role.tf
+++ b/role.tf
@@ -96,17 +96,6 @@ data "aws_iam_policy_document" "access_bastion" {
   }
 
   statement {
-    sid    = "ManipulateSchedule"
-    effect = "Allow"
-    actions = [
-      "autoscaling:BatchDeleteScheduledAction"
-    ]
-    resources = [
-      var.instance.enable_spot ? aws_autoscaling_group.on_spot.arn : aws_autoscaling_group.on_demand.arn
-    ]
-  }
-
-  statement {
     sid    = "SsmDescribeSSMConnection"
     effect = "Allow"
     actions = [

--- a/role.tf
+++ b/role.tf
@@ -96,6 +96,17 @@ data "aws_iam_policy_document" "access_bastion" {
   }
 
   statement {
+    sid    = "ManipulateSchedule"
+    effect = "Allow"
+    actions = [
+      "autoscaling:BatchDeleteScheduledAction"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
     sid    = "SsmDescribeSSMConnection"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
# Description

Using the panic button lambdas ended with `prod-platform-bastion-panic-button-on is not authorized to perform: autoscaling:BatchDeleteScheduledAction`. This PR adds the policy to the role to allow the lambda working

# Verification

Manually verified in HL environment.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
