### PR TITLE
chore: change code owners to whole team and limit access to license file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-* @kayman-mk @PascalFrenz
+*        @Quotation-And-Contract-Management
+
+LICENSE  @Organization-Defaults

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence.
 *        @hapag-lloyd/quotation-and-contract-management
 
-LICENSE  @kayman-mk
+LICENSE  @hapag-lloyd/organization-defaults

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*        @Quotation-And-Contract-Management
+*        @hapag-lloyd/quotation-and-contract-management
 
-LICENSE  @Organization-Defaults
+LICENSE  @kayman-mk


### PR DESCRIPTION
# Description

Make the whole team the owner of the code, but limit access to the license file to the admins as licenses have to be validated by lawyers and shouldn't be changed by everyone.