### PR TITLE
fix: terminate the instances instead of stopping them

### DIFF
--- a/lambda/panic_button_switch_off.py
+++ b/lambda/panic_button_switch_off.py
@@ -42,7 +42,7 @@ def kill_running_bastion_hosts(name):
                     instance_ids.append(i['InstanceId'])
 
             if instance_ids:
-                ec2.stop_instances(InstanceIds=instance_ids)
+                ec2.terminate_instances(InstanceIds=instance_ids)
 
                 logger.info("Bastion killed: %s", instance_ids)
     except ClientError as e:


### PR DESCRIPTION
# Description

Trigger the panic stop resulted in `you are not allowed to stop spot instances`. As we want to get rid of the whole instance, stopping is wrong. We need to terminate the instance, which works for spot instances too.

# Verification

Manually verified in the HL environment.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
