### PR TITLE
ci: use dedicated token to create a release

### DIFF
--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -9,11 +9,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@7bfa3a4717ef143a604ee0a99d859b8886a96d00 # v1.9.3
-        id: app-token
-        with:
-          app-id: ${{ vars.GET_TOKEN_APP_ID }}
-          private-key: ${{ secrets.GET_TOKEN_APP_PRIVATE_KEY }}
       - name: Release
         uses: google-github-actions/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
         with:
@@ -21,4 +16,5 @@ jobs:
           include-v-in-tag: false
           signoff: "Matthias Kay <matthias.kay@hlag.com>"
           bootstrap-sha: "5213931527b84359dbfe1725e803af318082443f"
-          token: ${{ steps.app-token.outputs.token }}
+          # temporary tokens do not work as they don't have access to protected tags
+          token: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}


### PR DESCRIPTION
# Description

Creating protected tags does not work with temporary tokens. Use a dedicated token which has the access permissions needed.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
