### PR TITLE
ci: set up team as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+*       @hapag-lloyd/quotation-and-contract-management
+
+# license file shouldn't be changed and needs to be reviewed by lawyers
+LICENSE @hapag-lloyd/organization-defaults

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence.
-* @kayman-mk @PascalFrenz


### PR DESCRIPTION
# Description

Use the QCM team as code-owner instead of single members. Allows our Bot to automatically confirm pull requests.