### PR TITLE
feat: add variable to make log-group retention configurable

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -14,6 +14,7 @@
     "tfsec"
   ],
   "ignoreWords": [
+    "awsx",
     "Buildx",
     "DOCKERHUB",
     "amannn",

--- a/panic-button-off.tf
+++ b/panic-button-off.tf
@@ -118,7 +118,7 @@ resource "aws_lambda_function" "panic_button_off" {
 
 resource "aws_cloudwatch_log_group" "panic_button_off" {
   name              = "/aws/lambda/${local.panic_button_switch_off_lambda_name}"
-  retention_in_days = 90
+  retention_in_days = var.log_group_retention_days
 
   kms_key_id = var.kms_key_arn
 

--- a/panic-button-off.tf
+++ b/panic-button-off.tf
@@ -118,7 +118,7 @@ resource "aws_lambda_function" "panic_button_off" {
 
 resource "aws_cloudwatch_log_group" "panic_button_off" {
   name              = "/aws/lambda/${local.panic_button_switch_off_lambda_name}"
-  retention_in_days = 3
+  retention_in_days = 90
 
   kms_key_id = var.kms_key_arn
 

--- a/panic-button-on.tf
+++ b/panic-button-on.tf
@@ -102,7 +102,7 @@ resource "aws_lambda_function" "panic_button_on" {
 
 resource "aws_cloudwatch_log_group" "panic_button_on" {
   name              = "/aws/lambda/${local.panic_button_switch_on_lambda_name}"
-  retention_in_days = 3
+  retention_in_days = 90
 
   kms_key_id = var.kms_key_arn
 

--- a/panic-button-on.tf
+++ b/panic-button-on.tf
@@ -102,7 +102,7 @@ resource "aws_lambda_function" "panic_button_on" {
 
 resource "aws_cloudwatch_log_group" "panic_button_on" {
   name              = "/aws/lambda/${local.panic_button_switch_on_lambda_name}"
-  retention_in_days = 90
+  retention_in_days = var.log_group_retention_days
 
   kms_key_id = var.kms_key_arn
 

--- a/variables.tf
+++ b/variables.tf
@@ -114,3 +114,9 @@ variable "ami_id" {
   description = "The AMI ID to use for the bastion host. If not set a default AMI is used which is updated regularly"
   default     = null
 }
+
+variable "log_group_retention_days" {
+  type        = number
+  description = "Number of days for the Cloudwatch Log-Group retention period"
+  default     = 5
+}


### PR DESCRIPTION
# Description

I have introduced a new variable `log_group_retention_days` to make the retention time of the log-group configurable.

Reason:
```Logging is a crucial aspect of maintaining a secure and reliable environment in systems. Logs can provide valuable insights into system operations, errors, access, usage patterns and potential security incidents. If a log group in CloudWatch is not configured to retain logs for a certain period of time, important data could be lost. In some cases, regulations and standards may also require logs to be retained for specific periods. Failing to retain logs for at least one year could hinder system troubleshooting, vulnerability detection, auditing, and compliance verification.```

