### PR TITLE
chore!: remove launch configuration

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -10,12 +10,14 @@
     "javadocs",
     "jsonencode",
     "oidc",
+    "rebalance",
     "Repology",
     "sonatype",
     "tflint",
     "tfsec"
   ],
   "ignoreWords": [
+    "AWSX",
     "Buildx",
     "DOCKERHUB",
     "amannn",
@@ -53,6 +55,7 @@
     "signoff",
     "temurin",
     "tfstate",
-    "vuln"
+    "vuln",
+    "xvda"
   ]
 }

--- a/examples/cost/main.tf
+++ b/examples/cost/main.tf
@@ -45,6 +45,7 @@ module "bastion_host" {
   instance = {
     type              = "t3.nano"
     desired_capacity  = 2
+    root_device_name  = "/dev/xvda"
     root_volume_size  = 8
     enable_monitoring = false
     enable_spot       = true

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -49,6 +49,7 @@ module "bastion_host" {
   instance = {
     type              = "t3.nano"
     desired_capacity  = 2
+    root_device_name  = "/dev/xvda"
     root_volume_size  = 8
     enable_monitoring = false
     enable_spot       = false

--- a/locals.tf
+++ b/locals.tf
@@ -23,8 +23,6 @@ locals {
   panic_button_switch_on_lambda_source           = "${path.module}/lambda/${local.panic_button_switch_on_lambda_source_file_name}"
   panic_button_switch_on_lambda_name             = "${var.resource_names.prefix}${var.resource_names.separator}panic-button-on"
 
-  auto_scaling_group = var.instance.enable_spot ? aws_autoscaling_group.on_spot[0] : aws_autoscaling_group.on_demand[0]
-
   # amiFilter=[{"Name":"owner-id","Values":["137112412989"]},{"Name":"name","Values":["amzn2-ami-hvm-*-x86_64-ebs"]}]
   # currentImageName=unknown
   default_ami_id = "ami-0dffacdad8c0f8540"

--- a/panic-button-off.tf
+++ b/panic-button-off.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "panic_button_off" {
   statement {
     sid       = "UpdateASG"
     actions   = ["autoscaling:UpdateAutoScalingGroup"]
-    resources = [local.auto_scaling_group.arn]
+    resources = [aws_autoscaling_group.this.arn]
     effect    = "Allow"
   }
 }
@@ -99,7 +99,7 @@ resource "aws_lambda_function" "panic_button_off" {
 
   environment {
     variables = {
-      AUTO_SCALING_GROUP_NAME = local.auto_scaling_group.name
+      AUTO_SCALING_GROUP_NAME = aws_autoscaling_group.this.name
       BASTION_HOST_NAME       = local.bastion_host_name
 
       LOG_LEVEL = "info"

--- a/panic-button-on.tf
+++ b/panic-button-on.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "panic_button_on" {
   statement {
     sid       = "UpdateASG"
     actions   = ["autoscaling:UpdateAutoScalingGroup", "autoscaling:BatchDeleteScheduledAction"]
-    resources = [local.auto_scaling_group.arn]
+    resources = [aws_autoscaling_group.this.arn]
     effect    = "Allow"
   }
 
@@ -81,10 +81,10 @@ resource "aws_lambda_function" "panic_button_on" {
 
   environment {
     variables = {
-      AUTO_SCALING_GROUP_NAME             = local.auto_scaling_group.name
-      AUTO_SCALING_GROUP_MIN_SIZE         = local.auto_scaling_group.min_size
-      AUTO_SCALING_GROUP_MAX_SIZE         = local.auto_scaling_group.max_size
-      AUTO_SCALING_GROUP_DESIRED_CAPACITY = local.auto_scaling_group.desired_capacity
+      AUTO_SCALING_GROUP_NAME             = aws_autoscaling_group.this.name
+      AUTO_SCALING_GROUP_MIN_SIZE         = aws_autoscaling_group.this.min_size
+      AUTO_SCALING_GROUP_MAX_SIZE         = aws_autoscaling_group.this.max_size
+      AUTO_SCALING_GROUP_DESIRED_CAPACITY = aws_autoscaling_group.this.desired_capacity
 
       LOG_LEVEL = "info"
     }

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,7 @@ variable "instance" {
   type = object({
     type              = string # EC2 instance type
     desired_capacity  = number # number of EC2 instances to run
+    root_device_name  = string
     root_volume_size  = number # in GB
     enable_monitoring = bool
     enable_spot       = bool
@@ -69,6 +70,7 @@ variable "instance" {
   default = {
     type              = "t3.nano"
     desired_capacity  = 1
+    root_device_name  = "/dev/xvda"
     root_volume_size  = 8
     enable_monitoring = false
     enable_spot       = false


### PR DESCRIPTION
# Description

The `aws_launch_configuration` is deprecated and replaced by `aws_launch_template`. This PR replaces the deprecated resources and combines the on-demand and spot settings into one launch template.

Fixes #383 

# Migrations required

Depending on the AMI used, you have to set the `var.instance.root_device_name`. We use `/dev/xvda` as default, which should work for Linux instances.