### PR TITLE
feat: add a variable to disable the panic switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ hosts are deactivated. The second lambda function disables the bastion host imme
 As both functions are destructive (they modify the autoscaling group), you have to re-apply this module as soon as
 possible to restore the auto scaling setting (especially the schedules).
 
+If your bastion host runs 24/7, you can disable the panic switch by setting `enable_panic_switches = false`.
+
 ### Keepass Support For IAM User Credentials
 
 In case you are not using SSO or similar techniques you have to store the credentials for the user able to

--- a/panic-button-off.tf
+++ b/panic-button-off.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "panic_button_off_execution" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   name                  = "${var.resource_names.prefix}${var.resource_names.separator}panic-button-off"
   description           = "Role for executing the bastion panic button switch off"
@@ -10,7 +10,7 @@ resource "aws_iam_role" "panic_button_off_execution" {
 }
 
 data "aws_iam_policy_document" "panic_button_off_assume_role" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   statement {
     actions = [
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "panic_button_off_assume_role" {
 }
 
 data "aws_iam_policy_document" "panic_button_off" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   statement {
     sid = "ListInstances"
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "panic_button_off" {
 }
 
 resource "aws_iam_policy" "panic_button_off" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   name   = "${var.resource_names.prefix}${var.resource_names.separator}switch-off"
   policy = data.aws_iam_policy_document.panic_button_off[0].json
@@ -71,28 +71,28 @@ resource "aws_iam_policy" "panic_button_off" {
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_off" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   role       = aws_iam_role.panic_button_off_execution[0].name
   policy_arn = aws_iam_policy.panic_button_off[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_off_basic_execution" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   role       = aws_iam_role.panic_button_off_execution[0].id
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_off_x_ray" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
   role       = aws_iam_role.panic_button_off_execution[0].id
 }
 
 data "archive_file" "panic_button_off_package" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   type        = "zip"
   source_file = local.panic_button_switch_off_lambda_source
@@ -100,7 +100,7 @@ data "archive_file" "panic_button_off_package" {
 }
 
 resource "aws_lambda_function" "panic_button_off" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   architectures    = ["arm64"]
   description      = "Terminates all bastion hosts forever"
@@ -135,7 +135,7 @@ resource "aws_lambda_function" "panic_button_off" {
 }
 
 resource "aws_cloudwatch_log_group" "panic_button_off" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   name              = "/aws/lambda/${local.panic_button_switch_off_lambda_name}"
   retention_in_days = var.log_group_retention_days

--- a/panic-button-off.tf
+++ b/panic-button-off.tf
@@ -1,13 +1,17 @@
 resource "aws_iam_role" "panic_button_off_execution" {
+  count = var.create_panic_switches ? 1 : 0
+
   name                  = "${var.resource_names.prefix}${var.resource_names.separator}panic-button-off"
   description           = "Role for executing the bastion panic button switch off"
-  assume_role_policy    = data.aws_iam_policy_document.panic_button_off_assume_role.json
+  assume_role_policy    = data.aws_iam_policy_document.panic_button_off_assume_role[0].json
   force_detach_policies = true
 
   tags = var.tags
 }
 
 data "aws_iam_policy_document" "panic_button_off_assume_role" {
+  count = var.create_panic_switches ? 1 : 0
+
   statement {
     actions = [
       "sts:AssumeRole",
@@ -22,6 +26,8 @@ data "aws_iam_policy_document" "panic_button_off_assume_role" {
 }
 
 data "aws_iam_policy_document" "panic_button_off" {
+  count = var.create_panic_switches ? 1 : 0
+
   statement {
     sid = "ListInstances"
     actions = [
@@ -56,45 +62,57 @@ data "aws_iam_policy_document" "panic_button_off" {
 }
 
 resource "aws_iam_policy" "panic_button_off" {
+  count = var.create_panic_switches ? 1 : 0
+
   name   = "${var.resource_names.prefix}${var.resource_names.separator}switch-off"
-  policy = data.aws_iam_policy_document.panic_button_off.json
+  policy = data.aws_iam_policy_document.panic_button_off[0].json
 
   tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_off" {
-  role       = aws_iam_role.panic_button_off_execution.name
-  policy_arn = aws_iam_policy.panic_button_off.arn
+  count = var.create_panic_switches ? 1 : 0
+
+  role       = aws_iam_role.panic_button_off_execution[0].name
+  policy_arn = aws_iam_policy.panic_button_off[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_off_basic_execution" {
+  count = var.create_panic_switches ? 1 : 0
+
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  role       = aws_iam_role.panic_button_off_execution.id
+  role       = aws_iam_role.panic_button_off_execution[0].id
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_off_x_ray" {
+  count = var.create_panic_switches ? 1 : 0
+
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
-  role       = aws_iam_role.panic_button_off_execution.id
+  role       = aws_iam_role.panic_button_off_execution[0].id
 }
 
 data "archive_file" "panic_button_off_package" {
+  count = var.create_panic_switches ? 1 : 0
+
   type        = "zip"
   source_file = local.panic_button_switch_off_lambda_source
   output_path = "${path.root}/builds/${local.panic_button_switch_off_lambda_source_file_name}.zip"
 }
 
 resource "aws_lambda_function" "panic_button_off" {
+  count = var.create_panic_switches ? 1 : 0
+
   architectures    = ["arm64"]
   description      = "Terminates all bastion hosts forever"
-  filename         = data.archive_file.panic_button_off_package.output_path
-  source_code_hash = data.archive_file.panic_button_off_package.output_base64sha256
+  filename         = data.archive_file.panic_button_off_package[0].output_path
+  source_code_hash = data.archive_file.panic_button_off_package[0].output_base64sha256
   function_name    = local.panic_button_switch_off_lambda_name
   handler          = "panic_button_switch_off.handler"
   timeout          = 30
   memory_size      = 256
   #package_type     = "Zip"
   publish = true
-  role    = aws_iam_role.panic_button_off_execution.arn
+  role    = aws_iam_role.panic_button_off_execution[0].arn
   runtime = "python3.9"
 
   environment {
@@ -113,10 +131,12 @@ resource "aws_lambda_function" "panic_button_off" {
   tags = var.tags
 
   # otherwise the Lambda auto-creates the group which conflicts with Terraform
-  depends_on = [aws_cloudwatch_log_group.panic_button_off]
+  depends_on = [aws_cloudwatch_log_group.panic_button_off[0]]
 }
 
 resource "aws_cloudwatch_log_group" "panic_button_off" {
+  count = var.create_panic_switches ? 1 : 0
+
   name              = "/aws/lambda/${local.panic_button_switch_off_lambda_name}"
   retention_in_days = var.log_group_retention_days
 

--- a/panic-button-on.tf
+++ b/panic-button-on.tf
@@ -1,13 +1,17 @@
 resource "aws_iam_role" "panic_button_on_execution" {
+  count = var.create_panic_switches ? 1 : 0
+
   name                  = "${var.resource_names.prefix}${var.resource_names.separator}panic-button-on"
   description           = "Role for executing the bastion panic button switch off"
-  assume_role_policy    = data.aws_iam_policy_document.panic_button_on_assume_role.json
+  assume_role_policy    = data.aws_iam_policy_document.panic_button_on_assume_role[0].json
   force_detach_policies = true
 
   tags = var.tags
 }
 
 data "aws_iam_policy_document" "panic_button_on_assume_role" {
+  count = var.create_panic_switches ? 1 : 0
+
   statement {
     actions = [
       "sts:AssumeRole",
@@ -22,6 +26,8 @@ data "aws_iam_policy_document" "panic_button_on_assume_role" {
 }
 
 data "aws_iam_policy_document" "panic_button_on" {
+  count = var.create_panic_switches ? 1 : 0
+
   statement {
     sid       = "UpdateASG"
     actions   = ["autoscaling:UpdateAutoScalingGroup", "autoscaling:BatchDeleteScheduledAction"]
@@ -38,45 +44,57 @@ data "aws_iam_policy_document" "panic_button_on" {
 }
 
 resource "aws_iam_policy" "panic_button_on" {
+  count = var.create_panic_switches ? 1 : 0
+
   name   = "${var.resource_names.prefix}${var.resource_names.separator}switch-on"
-  policy = data.aws_iam_policy_document.panic_button_on.json
+  policy = data.aws_iam_policy_document.panic_button_on[0].json
 
   tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_on" {
-  role       = aws_iam_role.panic_button_on_execution.name
-  policy_arn = aws_iam_policy.panic_button_on.arn
+  count = var.create_panic_switches ? 1 : 0
+
+  role       = aws_iam_role.panic_button_on_execution[0].name
+  policy_arn = aws_iam_policy.panic_button_on[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_on_basic_execution" {
+  count = var.create_panic_switches ? 1 : 0
+
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  role       = aws_iam_role.panic_button_on_execution.id
+  role       = aws_iam_role.panic_button_on_execution[0].id
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_on_x_ray" {
+  count = var.create_panic_switches ? 1 : 0
+
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
-  role       = aws_iam_role.panic_button_on_execution.id
+  role       = aws_iam_role.panic_button_on_execution[0].id
 }
 
 data "archive_file" "panic_button_on_package" {
+  count = var.create_panic_switches ? 1 : 0
+
   type        = "zip"
   source_file = local.panic_button_switch_on_lambda_source
   output_path = "${path.root}/builds/${local.panic_button_switch_on_lambda_source_file_name}.zip"
 }
 
 resource "aws_lambda_function" "panic_button_on" {
+  count = var.create_panic_switches ? 1 : 0
+
   architectures    = ["arm64"]
   description      = "Start all bastion hosts immediately"
-  filename         = data.archive_file.panic_button_on_package.output_path
-  source_code_hash = data.archive_file.panic_button_on_package.output_base64sha256
+  filename         = data.archive_file.panic_button_on_package[0].output_path
+  source_code_hash = data.archive_file.panic_button_on_package[0].output_base64sha256
   function_name    = local.panic_button_switch_on_lambda_name
   handler          = "panic_button_switch_on.handler"
   timeout          = 30
   memory_size      = 256
   package_type     = "Zip"
   publish          = true
-  role             = aws_iam_role.panic_button_on_execution.arn
+  role             = aws_iam_role.panic_button_on_execution[0].arn
   runtime          = "python3.9"
 
   environment {
@@ -97,10 +115,12 @@ resource "aws_lambda_function" "panic_button_on" {
   tags = var.tags
 
   # otherwise the Lambda auto-creates the group which conflicts with Terraform
-  depends_on = [aws_cloudwatch_log_group.panic_button_on]
+  depends_on = [aws_cloudwatch_log_group.panic_button_on[0]]
 }
 
 resource "aws_cloudwatch_log_group" "panic_button_on" {
+  count = var.create_panic_switches ? 1 : 0
+
   name              = "/aws/lambda/${local.panic_button_switch_on_lambda_name}"
   retention_in_days = var.log_group_retention_days
 

--- a/panic-button-on.tf
+++ b/panic-button-on.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "panic_button_on_execution" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   name                  = "${var.resource_names.prefix}${var.resource_names.separator}panic-button-on"
   description           = "Role for executing the bastion panic button switch off"
@@ -10,7 +10,7 @@ resource "aws_iam_role" "panic_button_on_execution" {
 }
 
 data "aws_iam_policy_document" "panic_button_on_assume_role" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   statement {
     actions = [
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "panic_button_on_assume_role" {
 }
 
 data "aws_iam_policy_document" "panic_button_on" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   statement {
     sid       = "UpdateASG"
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "panic_button_on" {
 }
 
 resource "aws_iam_policy" "panic_button_on" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   name   = "${var.resource_names.prefix}${var.resource_names.separator}switch-on"
   policy = data.aws_iam_policy_document.panic_button_on[0].json
@@ -53,28 +53,28 @@ resource "aws_iam_policy" "panic_button_on" {
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_on" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   role       = aws_iam_role.panic_button_on_execution[0].name
   policy_arn = aws_iam_policy.panic_button_on[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_on_basic_execution" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   role       = aws_iam_role.panic_button_on_execution[0].id
 }
 
 resource "aws_iam_role_policy_attachment" "panic_button_on_x_ray" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
   role       = aws_iam_role.panic_button_on_execution[0].id
 }
 
 data "archive_file" "panic_button_on_package" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   type        = "zip"
   source_file = local.panic_button_switch_on_lambda_source
@@ -82,7 +82,7 @@ data "archive_file" "panic_button_on_package" {
 }
 
 resource "aws_lambda_function" "panic_button_on" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   architectures    = ["arm64"]
   description      = "Start all bastion hosts immediately"
@@ -119,7 +119,7 @@ resource "aws_lambda_function" "panic_button_on" {
 }
 
 resource "aws_cloudwatch_log_group" "panic_button_on" {
-  count = var.create_panic_switches ? 1 : 0
+  count = var.enable_panic_switches ? 1 : 0
 
   name              = "/aws/lambda/${local.panic_button_switch_on_lambda_name}"
   retention_in_days = var.log_group_retention_days

--- a/variables.tf
+++ b/variables.tf
@@ -122,3 +122,9 @@ variable "connect_bastion_role_name" {
   type        = string
   description = "The name of the role to assume to connect to the bastion host."
 }
+
+variable "create_panic_switches" {
+  type        = bool
+  description = "If true, create the panic button Lambda switches to turn on/off the bastion host immediately."
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -123,7 +123,7 @@ variable "connect_bastion_role_name" {
   description = "The name of the role to assume to connect to the bastion host."
 }
 
-variable "create_panic_switches" {
+variable "enable_panic_switches" {
   type        = bool
   description = "If true, create the panic button Lambda switches to turn on/off the bastion host immediately."
   default     = true


### PR DESCRIPTION
<!--- yamllint disable rule:single-title/single-h1 -->
# Description

Adds `create_panic_switches` to disable all resources related to the Lambda panic switches. In case they are not needed, e. g. the bastion runs 24/7, there is no need to create these resources.

Fixes #401 

# Verification

Plan was created and checked against the development account.