### PR TITLE
fix: add provider default tags to autoscaling group

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -4,6 +4,7 @@ locals {
   resource_prefix_with_separator = "${var.resource_names["prefix"]}${var.resource_names["separator"]}"
 
   bastion_runtime_tags = merge(
+    data.aws_default_tags.this.tags,
     var.tags,
     {
       "Name"                          = local.bastion_host_name

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
-data "aws_region" "this" {
-}
+data "aws_region" "this" {}
+
+data "aws_default_tags" "this" {}
 
 resource "aws_ami_copy" "latest_amazon_linux" {
   name        = var.resource_names["prefix"]


### PR DESCRIPTION
# Description

The tags of the `aws_autoscaling_group` require an additional setting `propagate_at_launch`. Thus the default tags from the provider are not automatically used.

This PR reads the default tags and adds them with `propagate_at_launch = true`. Usually needed to comply with tagging strategies.