### PR TITLE
fix: update python runtime for panic lambdas to python3.13

### DIFF
--- a/panic-button-off.tf
+++ b/panic-button-off.tf
@@ -113,7 +113,7 @@ resource "aws_lambda_function" "panic_button_off" {
   #package_type     = "Zip"
   publish = true
   role    = aws_iam_role.panic_button_off_execution[0].arn
-  runtime = "python3.9"
+  runtime = "python3.13"
 
   environment {
     variables = {

--- a/panic-button-on.tf
+++ b/panic-button-on.tf
@@ -95,7 +95,7 @@ resource "aws_lambda_function" "panic_button_on" {
   package_type     = "Zip"
   publish          = true
   role             = aws_iam_role.panic_button_on_execution[0].arn
-  runtime          = "python3.9"
+  runtime          = "python3.13"
 
   environment {
     variables = {


### PR DESCRIPTION
# Description

AWS Lambda supports newer versions of python already since quite some time. Now that the deprecation deadline for the `python3.9` runtime is approaching, we should update the runtime for the kill-switch lambdas to the newest supported version which is `python3.13`

# Verification

The code does not contain any language features which would be incompatible with 3.13.
The only dependency, boto3, is compatible with Python 3.13: https://pypi.org/project/boto3/

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
